### PR TITLE
Only run CI on Rust stable for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,7 +36,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
So that the latest features of the language can be used during
development.