### PR TITLE
Enforce contiguous part IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@ pub trait Partition<M> {
 
     /// Partition the given data and output the part ID of each element in
     /// `part_ids`.
+    ///
+    /// Part IDs must be contiguous and start from zero, meaning the number of
+    /// parts is one plus the maximum of `part_ids`.  If a lower ID does not
+    /// appear in the array, the part is assumed to be empty.
     fn partition(&mut self, part_ids: &mut [usize], data: M)
         -> Result<Self::Metadata, Self::Error>;
 }


### PR DESCRIPTION
This upholds expectations of part-info and fidducia-mattheyses that
expected the maximum of the partition array to be the number of parts.

Closes #79