### PR TITLE
tools: add medit2svg

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -17,7 +17,7 @@ pub type PointND<const D: usize> = SVector<f64, D>;
 pub type Matrix<const D: usize> = SMatrix<f64, D, D>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Aabb<const D: usize> {
+pub struct Aabb<const D: usize> {
     p_min: PointND<D>,
     p_max: PointND<D>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod topology;
 mod uid;
 
 pub use crate::algorithms::*;
+pub use crate::geometry::Aabb;
 pub use crate::geometry::{Point2D, Point3D, PointND};
 pub use crate::nextafter::nextafter;
 pub use crate::real::Real;

--- a/tools/src/bin/medit2svg.rs
+++ b/tools/src/bin/medit2svg.rs
@@ -1,0 +1,291 @@
+use anyhow::Context as _;
+use anyhow::Result;
+use coupe::Point2D;
+use mesh_io::medit::ElementType;
+use mesh_io::medit::Mesh;
+use std::collections::HashSet;
+use std::env;
+use std::io;
+
+/// Returns the list of elements that are interesting.
+fn elements(mesh: &Mesh) -> impl Iterator<Item = (ElementType, &[usize], isize)> {
+    mesh.elements()
+        .filter(|(el_type, _el_nodes, _el_ref)| el_type.dimension() == mesh.dimension())
+}
+
+/// Returns a function that looks up an element given its ID.
+fn element_lookup<'a>(mesh: &'a Mesh) -> impl Fn(usize) -> (ElementType, &'a [usize], isize) + 'a {
+    struct ElementChunk<'a> {
+        start_idx: usize,
+        node_per_element: usize,
+        nodes: &'a [usize],
+    }
+    let topology: Vec<ElementChunk> = mesh
+        .topology()
+        .iter()
+        .filter(|(el_type, _nodes, _refs)| el_type.dimension() == mesh.dimension())
+        .scan(0, |start_idx, (el_type, nodes, _refs)| {
+            let item = ElementChunk {
+                start_idx: *start_idx,
+                node_per_element: el_type.node_count(),
+                nodes,
+            };
+            *start_idx += nodes.len() / item.node_per_element;
+            Some(item)
+        })
+        .collect();
+    move |e| {
+        for (item, t) in topology.iter().zip(mesh.topology()) {
+            let e = e - item.start_idx;
+            let e_node = e * item.node_per_element;
+            if e_node < item.nodes.len() {
+                let el_type = t.0;
+                let el_nodes = &item.nodes[e_node..e_node + item.node_per_element];
+                let el_ref = t.2[e];
+                return (el_type, el_nodes, el_ref);
+            }
+        }
+        unreachable!();
+    }
+}
+
+/// Adds an element and its neighbors that have the same ref as `path_ref` to
+/// `el_set`.
+fn add_element_and_neighbors_to_path<'a>(
+    el_set: &mut HashSet<usize>,
+    path_ref: isize,
+    el: usize,
+    element_fn: impl Fn(usize) -> (ElementType, &'a [usize], isize) + Copy,
+    adjacency: sprs::CsMatView<f64>,
+) {
+    let (_el_type, _el_nodes, el_ref) = element_fn(el);
+    if el_ref != path_ref || !el_set.insert(el) {
+        return;
+    }
+    for (neighbor, _) in adjacency.outer_view(el).unwrap().iter() {
+        add_element_and_neighbors_to_path(el_set, path_ref, neighbor, element_fn, adjacency);
+    }
+}
+
+fn twobytwo(path: &[usize]) -> impl Iterator<Item = (usize, usize)> + '_ {
+    path.iter()
+        .zip(path[1..].iter().chain(std::iter::once(&path[0])))
+        .map(|(node1, node2)| (*node1, *node2))
+}
+
+/// Merge a collection of connected paths into several unconnected paths.
+///
+/// Input paths are unordered lists of nodes, output paths are ordered lists of
+/// nodes.
+fn merge_paths(mut paths: Vec<Vec<usize>>) -> impl Iterator<Item = Vec<usize>> {
+    std::iter::from_fn(move || {
+        let mut p = match paths.pop() {
+            Some(v) => v,
+            None => return None,
+        };
+        let mut p_end = *p.last().unwrap();
+
+        let mut merged_path = Vec::new();
+        merged_path.extend_from_slice(&p);
+
+        loop {
+            p = match paths.iter().position(|q| {
+                let q_start = *q.first().unwrap();
+                let q_end = *q.last().unwrap();
+                p_end == q_start || p_end == q_end
+            }) {
+                Some(idx) => {
+                    let mut q = paths.remove(idx);
+                    let q_start = q[0];
+                    if p_end == q_start {
+                        merged_path.pop();
+                    } else {
+                        q.pop();
+                        q.reverse();
+                    }
+                    q
+                }
+                None => break,
+            };
+            p_end = *p.last().unwrap();
+            merged_path.extend_from_slice(&p);
+        }
+
+        Some(merged_path)
+    })
+}
+
+/// Returns the path that goes around the given set of elements.
+fn frontier<'a>(
+    el_set: &HashSet<usize>,
+    mesh: &Mesh,
+    element_fn: impl Fn(usize) -> (ElementType, &'a [usize], isize),
+    adjacency: sprs::CsMatView<f64>,
+) -> Vec<Vec<Point2D>> {
+    let path_set = el_set
+        .iter()
+        .filter(|el| {
+            // Select only frontier nodes:
+            let neighbors_in_set = adjacency
+                .outer_view(**el)
+                .unwrap()
+                .iter()
+                .filter(|(neighbor, _)| el_set.contains(neighbor))
+                .count();
+            let (el_type, _, _) = element_fn(**el);
+            let neighbors_total = el_type.node_count();
+            neighbors_in_set != neighbors_total
+        })
+        .flat_map(|el| {
+            // Select only edges that are not shared with neighbors in el_set:
+            let (_, el_nodes, _) = element_fn(*el);
+            let edges = twobytwo(el_nodes)
+                .filter(|(node1, node2)| {
+                    let is_within_el_set = adjacency
+                        .outer_view(*el)
+                        .unwrap()
+                        .iter()
+                        .filter(|(neighbor, _)| el_set.contains(neighbor))
+                        .any(|(neighbor, _)| {
+                            let (_, neighbor_nodes, _) = element_fn(neighbor);
+                            neighbor_nodes.contains(node1) && neighbor_nodes.contains(node2)
+                        });
+                    !is_within_el_set
+                })
+                .map(|(n1, n2)| vec![n1, n2])
+                .collect();
+            merge_paths(edges)
+        })
+        .collect();
+    merge_paths(path_set)
+        .into_iter()
+        .map(|path| {
+            path.into_iter()
+                .map(|node| {
+                    let coords = mesh.node(node);
+                    Point2D::from([coords[0], coords[1]])
+                })
+                .collect()
+        })
+        .collect()
+}
+
+struct Path {
+    nodes: Vec<Vec<Point2D>>,
+    color: isize,
+}
+
+/// Returns the list of "blobs"/frontiers/paths of the mesh's elements that
+/// share the same reference.
+fn paths(mesh: &Mesh) -> impl Iterator<Item = Path> + '_ {
+    let adjacency = coupe_tools::dual(mesh);
+    let mut visited = HashSet::new();
+    let element_fn = element_lookup(mesh);
+
+    elements(mesh)
+        .enumerate()
+        .filter_map(move |(el, (_el_type, _el_nodes, el_ref))| {
+            if visited.contains(&el) {
+                return None;
+            }
+
+            let mut el_set = HashSet::new();
+            add_element_and_neighbors_to_path(
+                &mut el_set,
+                el_ref,
+                el,
+                &element_fn,
+                adjacency.view(),
+            );
+
+            let nodes = frontier(&el_set, mesh, &element_fn, adjacency.view());
+
+            visited.extend(el_set);
+
+            Some(Path {
+                nodes,
+                color: el_ref,
+            })
+        })
+}
+
+fn write_svg<W>(mut w: W, mesh: &Mesh) -> Result<()>
+where
+    W: io::Write,
+{
+    let coordinates = unsafe {
+        std::slice::from_raw_parts(
+            mesh.coordinates().as_ptr() as *const Point2D,
+            mesh.node_count(),
+        )
+    };
+    let aabb = coupe::Aabb::<2>::from_points(coordinates);
+    let [xmin, ymin] = <[f64; 2]>::from(*aabb.p_min());
+    let [xmax, ymax] = <[f64; 2]>::from(*aabb.p_max());
+    let width = xmax - xmin;
+    let height = ymax - ymin;
+    writeln!(
+        w,
+        r#"<svg viewBox="{xmin} {ymin} {width} {height}" xmlns="http://www.w3.org/2000/svg">"#,
+    )?;
+
+    let color = {
+        let ref_count = 1 + elements(mesh)
+            .map(|(_, _, el_ref)| el_ref)
+            .max()
+            .unwrap_or(0);
+        move |el_ref| {
+            let brightness = (el_ref as f64 / ref_count as f64 * 256.0) as isize;
+            brightness << 16 | brightness << 8 | brightness
+        }
+    };
+    for path in paths(mesh) {
+        write!(
+            w,
+            "<path fill=\"#{:06x}\" fill-rule=\"evenodd\" d=\"",
+            color(path.color),
+        )?;
+        for node_list in path.nodes {
+            let (first_node, nodes) = node_list.split_first().unwrap();
+            write!(w, " M{},{} L", first_node[0], ymax - first_node[1] + ymin)?;
+            for coords in nodes {
+                write!(w, "{},{} ", coords[0], ymax - coords[1] + ymin)?;
+            }
+            write!(w, "Z")?;
+        }
+        writeln!(w, "\"/>")?;
+    }
+
+    writeln!(w, "</svg>")?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let mut options = getopts::Options::new();
+    options.optflag("h", "help", "print this help menu");
+
+    let matches = options.parse(env::args().skip(1))?;
+
+    if matches.opt_present("h") {
+        eprintln!("{}", options.usage("Usage: medit2svg [options]"));
+        return Ok(());
+    }
+
+    eprintln!("Reading mesh from stdin...");
+    let stdin = io::stdin();
+    let stdin = stdin.lock();
+    let stdin = io::BufReader::new(stdin);
+    let mesh = Mesh::from_reader(stdin).context("failed to read mesh")?;
+
+    eprintln!("Writing SVG to stdout...");
+    let stdout = io::stdout();
+    let stdout = stdout.lock();
+    let stdout = io::BufWriter::new(stdout);
+    match mesh.dimension() {
+        2 => write_svg::<_>(stdout, &mesh)?,
+        n => anyhow::bail!("expected 2D mesh, got a {n}D mesh"),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Converts a medit file (.mesh) to a somewhat lightweight SVG file.

Doesn't work right now.

We want a SVG following this format:

    <svg viewBox="xmin ymin width height" xmlns="???">
    <path d="..." fill="#abcdef"/>
    <path d="..." fill="#abcdef"/>
    ...
    </svg>

Each path's "d" attribute is a list of commands (M for move, L for line,
Z to close and fill) that draw a path, for example:

    <path d="M 0 0 L 0 10 L 10 10 L 10 0 Z" fill="red" />

draws a red square between (0,0) and (10,10), and

    <path d="M 0 0 L 10 0 L 0 10 Z" fill="black" />

draws half of this square in black.

A naive approach to convert mesh files to SVGs is simply to make a path
for each cell.  It works, but consumes both a lot of space and a lot of
processing power to render it.

So I'm trying to figure out how to get a path for each equivalence
class.  Turns out there are many edges cases and is a lot more tedious
than I expected...

Finding out equivalence classes is easy, and so is finding cells at the
frontier of these classes.  The problem is converting the set of cells
in the frontier to a list of nodes that make up a path.

Some problems I encountered:

1. the path must be ordered, otherwise it will not render well,
2. there can be nested equivalence classes, and they will therefore lead
   to 2 or more paths, one for the outside and one for each nested
   equivalence class,
3. some nodes can appear *twice* in a path, for example see this quad
   mesh with two classes `X` and `.`:

       ....
       ..X.
       XX..  <-- the . on the left of this row, its upper left node
       XXXX      appears twice on `.`'s path, because it's also a node
                 of the upper left `.`