### PR TITLE
Disable a buggy clippy lint

### DIFF
--- a/src/algorithms/ckk.rs
+++ b/src/algorithms/ckk.rs
@@ -38,6 +38,7 @@ fn ckk_bipart_build(partition: &mut [usize], last_weight: usize, steps: &[Step])
     }
 }
 
+#[allow(clippy::ptr_arg)] // clippy bug
 fn ckk_bipart_rec<T>(
     partition: &mut [usize],
     weights: &mut Vec<(T, usize)>,


### PR DESCRIPTION
Update to Rust 1.60 extended clippy::ptr_arg somehow and now this
triggers a false positive.

See https://github.com/rust-lang/rust-clippy/issues/8482

maybe relevant PR: https://github.com/rust-lang/rust-clippy/pull/8271