### PR TITLE
(don't merge) fm: worst

### DIFF
--- a/src/algorithms/fiduccia_mattheyses.rs
+++ b/src/algorithms/fiduccia_mattheyses.rs
@@ -140,10 +140,10 @@ where
         // number of vertices in the mesh. However, if too many subsequent
         // bad flips are performed, the loop will break early
         for move_num in 0..max_moves_per_pass {
-            let (moved_vertex, move_gain) = match gain_to_vertex
+            let (moved_vertex, move_gain) = match gain_to_vertex[gain_table_idx(1)..]
                 .iter()
-                .rev()
-                .zip((-max_possible_gain..=max_possible_gain).rev())
+                .chain(gain_to_vertex[..gain_table_idx(1)].iter().rev())
+                .zip((1..=max_possible_gain).chain((-max_possible_gain..1).rev()))
                 .find_map(|(vertices, gain)| {
                     let (best_vertex, _) = vertices
                         .iter()


### PR DESCRIPTION
Related to #70, though this version is not meant to be multi-threadable. It's the same as FM, but takes the smallest possible gain instead of the highest.

It does improve the edge cut a bit compared to FM, but not as much as FM+bad moves.