### PR TITLE
reports: truncate baseline names to 64 characters

### DIFF
--- a/tools/report/efficiency
+++ b/tools/report/efficiency
@@ -23,7 +23,7 @@ svg="$BASELINE.strong.svg"
 bg_path() {
 	benchmark_group=$1
 
-	benchmark_dir=$(echo "$benchmark_group" | tr ':' '_')
+	benchmark_dir=$(echo "$benchmark_group" | tr ':' '_' | cut -b-64)
 	echo "$TARGET_DIR/criterion/$benchmark_dir"
 }
 


### PR DESCRIPTION
See
https://github.com/bheisler/criterion.rs/blob/614236bfcc504090d38a8cac8c3436cd58688dda/src/report.rs#L87