### PR TITLE
part-bench: set thread affinity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "affinity"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763e484feceb7dd021b21c5c6f81aee06b1594a743455ec7efbf72e6355e447b"
+dependencies = [
+ "cfg-if",
+ "errno",
+ "libc",
+ "num_cpus",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +209,7 @@ dependencies = [
 name = "coupe-tools"
 version = "0.1.0"
 dependencies = [
+ "affinity",
  "anyhow",
  "coupe",
  "criterion",
@@ -316,6 +335,27 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "event-listener"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -39,4 +39,5 @@ criterion = { version = "0.3", default-features = false }
 itertools = { version = "0.10", default-features = false }
 num = { version = "0.4", default-features = false }
 rayon = "1.3"
+affinity = { version = "0.1", default-features = false }
 sprs = { version = "0.11", default-features = false, features = ["multi_thread"] }


### PR DESCRIPTION
Cherry-picked from #114 

This allows runs of part-bench to be more deterministic, since thread
placements is now grouped by default.  Before, on low thread runs,
threads could be spread out on different memory regions, which made
algorithms run slower sometimes.

Now threads are placed in a compact way accross cores (first N threads
are on the first N cores).