### PR TITLE
Move rcb::work_share into its own module

### DIFF
--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -518,28 +518,6 @@ fn rcb_thread<const D: usize, W>(
     futures_lite::future::block_on(task);
 }
 
-/// Split `total_work` among a given number of threads.
-///
-/// Returns `(thread_count, work_per_thread)`, where `thread_count` is the
-/// amount of threads that have actual work, and `work_per_thread` is the
-/// maximum amount of work these thread have (RCB here splits by chunks, thus
-/// the last thread will not have this much work).
-///
-/// # Panics
-///
-/// Panics if either argument is zero.
-fn work_share(total_work: usize, max_threads: usize) -> (usize, usize) {
-    let max_threads = usize::min(total_work, max_threads);
-
-    // ceil(total_work / max_threads)
-    let work_per_thread = (total_work + max_threads - 1) / max_threads;
-
-    // ceil(total_work / work_per_thread)
-    let thread_count = (total_work + work_per_thread - 1) / work_per_thread;
-
-    (work_per_thread, thread_count)
-}
-
 fn rcb<const D: usize, P, W>(
     partition: &mut [usize],
     points: P,
@@ -588,7 +566,8 @@ where
             part,
         })
         .collect();
-    let (items_per_thread, thread_count) = work_share(items.len(), rayon::current_num_threads());
+    let (items_per_thread, thread_count) =
+        crate::work_share(items.len(), rayon::current_num_threads());
     let iteration_ctxs: Vec<_> = (0..usize::pow(2, iter_count as u32 + 1) - 1)
         .map(|_| IterationState::new(thread_count))
         .collect();
@@ -1025,25 +1004,6 @@ mod tests {
         axis_sort(&points, &mut permutation, 1);
 
         assert_eq!(permutation, vec![3, 6, 5, 1, 0, 2, 4]);
-    }
-
-    #[test]
-    fn test_work_share() {
-        assert_eq!(work_share(100, 4), (25, 4));
-        assert_eq!(work_share(101, 4), (26, 4));
-
-        assert_eq!(work_share(100, 20), (5, 20));
-        assert_eq!(work_share(101, 20), (6, 17));
-
-        assert_eq!(work_share(100, 100), (1, 100));
-        assert_eq!(work_share(100, 101), (1, 100));
-
-        assert_eq!(work_share(100, 1), (100, 1));
-        assert_eq!(work_share(100, 2), (50, 2));
-        assert_eq!(work_share(100, 3), (34, 3));
-        assert_eq!(work_share(1, 100), (1, 1));
-        assert_eq!(work_share(2, 100), (1, 2));
-        assert_eq!(work_share(3, 100), (1, 3));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod nextafter;
 mod real;
 pub mod topology;
 mod uid;
+mod work_share;
 
 pub use crate::algorithms::*;
 pub use crate::geometry::Aabb;
@@ -43,6 +44,7 @@ pub use crate::geometry::{Point2D, Point3D, PointND};
 pub use crate::nextafter::nextafter;
 pub use crate::real::Real;
 pub use crate::uid::uid;
+use crate::work_share::work_share;
 
 /// The `Partition` trait allows for partitioning data.
 ///

--- a/src/work_share.rs
+++ b/src/work_share.rs
@@ -1,0 +1,45 @@
+/// Split `total_work` among a given number of threads.
+///
+/// Returns `(thread_count, work_per_thread)`, where `thread_count` is the
+/// amount of threads that have actual work, and `work_per_thread` is the
+/// maximum amount of work these thread have (RCB here splits by chunks, thus
+/// the last thread will not have this much work).
+///
+/// # Panics
+///
+/// Panics if either argument is zero.
+pub fn work_share(total_work: usize, max_threads: usize) -> (usize, usize) {
+    let max_threads = usize::min(total_work, max_threads);
+
+    // ceil(total_work / max_threads)
+    let work_per_thread = (total_work + max_threads - 1) / max_threads;
+
+    // ceil(total_work / work_per_thread)
+    let thread_count = (total_work + work_per_thread - 1) / work_per_thread;
+
+    (work_per_thread, thread_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_work_share() {
+        assert_eq!(work_share(100, 4), (25, 4));
+        assert_eq!(work_share(101, 4), (26, 4));
+
+        assert_eq!(work_share(100, 20), (5, 20));
+        assert_eq!(work_share(101, 20), (6, 17));
+
+        assert_eq!(work_share(100, 100), (1, 100));
+        assert_eq!(work_share(100, 101), (1, 100));
+
+        assert_eq!(work_share(100, 1), (100, 1));
+        assert_eq!(work_share(100, 2), (50, 2));
+        assert_eq!(work_share(100, 3), (34, 3));
+        assert_eq!(work_share(1, 100), (1, 1));
+        assert_eq!(work_share(2, 100), (1, 2));
+        assert_eq!(work_share(3, 100), (1, 3));
+    }
+}


### PR DESCRIPTION
It can be useful for other algorithms (#114 especially), and is not really specific to RCB