### PR TITLE
Add a C interface to coupe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ perf.data.old
 
 # generated man pages
 tools/doc/*.1
+
+# generated documentation
+/build
+/ffi/build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "coupe-ffi"
+version = "0.1.0"
+dependencies = [
+ "coupe",
+ "nalgebra",
+ "num",
+ "rayon",
+ "sprs",
+]
+
+[[package]]
 name = "coupe-tools"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "ffi",
     "tools",
     "tools/mesh-io",
     "tools/mesh-io/ffi",

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ example usages of the library.
 
 ### From other languages
 
-Coupe can only be used from Rust, for now.  Interoperability with other
-languages will be available through C bindings, and is a work in progress.  See
-[the relevant PR][67] for more information.
+Coupe offers a C interface which can be found in the `ffi/` directory.
+
+Bindings for other languages have not been made yet.  If you end up developing
+such bindings, please send us a note so they can be shown here!
 
 ## Contributing
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "coupe-ffi"
+version = "0.1.0"
+edition = "2021"
+
+
+[lib]
+name = "coupe"
+crate-type = [
+    "cdylib",
+    "staticlib",
+]
+
+
+[dependencies]
+coupe = { version = "0.1", path = ".." }
+nalgebra =  "0.29"
+num = "0.4"
+rayon = "1.3"
+sprs = { version = "0.11", default-features = false }

--- a/ffi/Doxyfile
+++ b/ffi/Doxyfile
@@ -1,0 +1,10 @@
+# Doxyfile 1.9.3
+
+PROJECT_NAME           = coupe
+PROJECT_BRIEF          = the concurrent partitioner
+OUTPUT_DIRECTORY       = build
+OPTIMIZE_OUTPUT_FOR_C  = YES
+EXTRACT_ALL            = YES
+QUIET                  = YES
+INPUT                  = README.md include/
+USE_MDFILE_AS_MAINPAGE = README.md

--- a/ffi/Makefile
+++ b/ffi/Makefile
@@ -1,0 +1,29 @@
+RUSTTARGET ?= ./target
+PREFIX ?= /usr/local
+
+CARGO ?= cargo
+SCDOC ?= scdoc
+DOXYGEN ?= doxygen
+LIBDIR ?= lib
+INCDIR ?= include
+
+all: coupe
+
+coupe:
+	$(CARGO) build --locked --release
+
+doc:
+	$(DOXYGEN) Doxyfile
+	@echo "HTML docs generated at \e]8;;file://$(PWD)/build/html/index.html\e\\\\build/html\e]8;;\e\\"
+
+clean:
+	$(CARGO) clean
+
+install:
+	mkdir -p $(DESTDIR)$(PREFIX)/$(LIBDIR)
+	mkdir -p $(DESTDIR)$(PREFIX)/$(INCDIR)
+	cp -f include/coupe.h $(DESTDIR)$(PREFIX)/$(INCDIR)/
+	cp -f $(RUSTTARGET)/release/libcoupe.a $(DESTDIR)$(PREFIX)/$(LIBDIR)/
+	cp -f $(RUSTTARGET)/release/libcoupe.so $(DESTDIR)$(PREFIX)/$(LIBDIR)/
+
+.PHONY: coupe clean doc install

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -1,0 +1,39 @@
+# libcoupe.so
+
+C interface to coupe.
+
+## Building
+
+You can build this project with cargo, or use the provided Makefile:
+
+```
+make
+sudo make install
+```
+
+Both a static (`libcoupe.a`) and a dynamic (`libcoupe.so`) library are produced.
+
+**Note:** while we try our best to limit panics, coupe is not free of them. We
+recommend packagers to keep the default `panic = "unwind"` or
+`RUSTFLAGS="-Cpanic=unwind"` flag, so that they can be caught and do not abort
+the whole process.
+
+## Usage
+
+These bindings target C99, but should work with later versions of the language.
+
+A couple example usages can be found in the `examples/` directory.
+
+## Documentation
+
+The full documentation is written as doc comments in `include/coupe.h` and
+should be seamlessly understood by IDEs and language servers.
+
+A simple `Doxyfile` and make target are also provided to generate HTML and LaTeX
+documents:
+
+```
+make doc
+```
+
+Generated documentation is placed inside a newly created `build/` directory.

--- a/ffi/examples/kk_fm.c
+++ b/ffi/examples/kk_fm.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include "../include/coupe.h"
+
+#define POINT_COUNT 9
+#define DIMENSION 2
+
+static void
+print_partition(uintptr_t partition[POINT_COUNT])
+{
+	printf("\n"
+	       "  %ld---%ld---%ld\n"
+	       "  |   |   |\n"
+	       "  %ld---%ld---%ld\n"
+	       "  |   |   |\n"
+	       "  %ld---%ld---%ld\n"
+	       "\n",
+	       partition[2], partition[5], partition[8],
+	       partition[1], partition[4], partition[7],
+	       partition[0], partition[3], partition[6]);
+}
+
+int
+main()
+{
+	/* Let's define a graph:
+	 *
+	 *     Node IDs:       Weights:
+	 *
+	 *     2    5    8     3    4    5
+	 *      +---+---+       +---+---+
+	 *      |   |   |       |   |   |
+	 *     1+---4---+7     2+---3---+4
+	 *      |   |   |       |   |   |
+	 *      +---+---+       +---+---+
+	 *     0    3    6     1    2    3
+	 */
+	double point_array[POINT_COUNT][DIMENSION] = {
+		{0.0, 0.0},
+		{0.0, 1.0},
+		{0.0, 2.0},
+		{1.0, 0.0},
+		{1.0, 1.0},
+		{1.0, 2.0},
+		{2.0, 0.0},
+		{2.0, 1.0},
+		{2.0, 2.0},
+	};
+
+	int weight_array[POINT_COUNT] = { 1, 2, 3, 2, 3, 4, 3, 4, 5 };
+	coupe_data *weights = coupe_data_array(POINT_COUNT, COUPE_INT, weight_array);
+	if (weights == NULL) {
+		fprintf(stderr, "Out of memory\n");
+		return 1;
+	}
+
+	uintptr_t xadj[POINT_COUNT+1] = {0, 2, 5, 7, 10, 14, 17, 19, 22, 24};
+	uintptr_t adjncy[24] =
+	{1, 3, 0, 2, 4, 1, 5, 0, 4, 6, 1, 3, 5, 7, 2, 4, 8, 3, 7, 4, 6, 8, 5, 7};
+	int64_t edge_weights[24] =
+	{1, 1, 1, 2, 2, 2, 3, 1, 2, 2, 2, 2, 3, 3, 3, 2, 4, 2, 3, 3, 3, 4, 4, 4};
+	struct coupe_adjncy *adjacency =
+		coupe_adjncy_csr(POINT_COUNT, xadj, adjncy, COUPE_INT64, edge_weights);
+	if (adjacency == NULL) {
+		fprintf(stderr, "Either out of memory, or invalid adjacency structure\n");
+		coupe_data_free(weights);
+		return 1;
+	}
+
+	uintptr_t partition[POINT_COUNT];
+
+	/* Let's run the Karmarkar-Karp algorithm on this graph: */
+	uintptr_t part_count = 2;
+	enum coupe_err err = coupe_karmarkar_karp(partition, weights, part_count);
+	if (err != COUPE_ERR_OK) {
+		fprintf(stderr, "Error: %s\n", coupe_strerror(err));
+		coupe_adjncy_free(adjacency);
+		coupe_data_free(weights);
+		return 1;
+	}
+
+	printf("Initial partitioning with Karmarkar-Karp:\n");
+	print_partition(partition);
+
+	/* Let's refine the partition with Fiduccia-Mattheyses: */
+	err = coupe_fiduccia_mattheyses(partition, adjacency, weights, 0, 0, 0.3, 0);
+	if (err != COUPE_ERR_OK) {
+		fprintf(stderr, "Error: %s\n", coupe_strerror(err));
+		coupe_adjncy_free(adjacency);
+		coupe_data_free(weights);
+		return 1;
+	}
+
+	printf("Partition refined by Fiduccia-Mattheyses:\n");
+	print_partition(partition);
+
+	coupe_adjncy_free(adjacency);
+	coupe_data_free(weights);
+	return 0;
+}

--- a/ffi/examples/rcb.c
+++ b/ffi/examples/rcb.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include "../include/coupe.h"
+
+#define POINT_COUNT 4
+#define DIMENSION 2
+
+int
+main()
+{
+	uintptr_t partition[POINT_COUNT];
+
+	double point_array[POINT_COUNT][DIMENSION] = {
+		{0.0, 0.0},
+		{0.0, 1.0},
+		{1.0, 0.0},
+		{1.0, 1.0},
+	};
+	struct coupe_data *points = coupe_data_array(POINT_COUNT, COUPE_DOUBLE, point_array);
+
+	int one = 1;
+	struct coupe_data *weights = coupe_data_constant(POINT_COUNT, COUPE_INT, &one);
+
+	uintptr_t iter_count = 1;
+	double tolerance = 0.05;
+	enum coupe_err err =
+		coupe_rcb(partition, DIMENSION, points, weights, iter_count, tolerance);
+
+	printf("With 1 iteration (2 parts), RCB returned: %s\n", coupe_strerror(err));
+	printf("partition:\n");
+	printf("%ld %ld\n%ld %ld\n", partition[0], partition[1], partition[2], partition[3]);
+
+	iter_count = 2;
+	err = coupe_rcb(partition, DIMENSION, points, weights, iter_count, tolerance);
+
+	printf("With 2 iterations (4 parts), RCB returned: %s\n", coupe_strerror(err));
+	printf("partition:\n");
+	printf("%ld %ld\n%ld %ld\n", partition[0], partition[1], partition[2], partition[3]);
+
+	coupe_data_free(points);
+	coupe_data_free(weights);
+	return 0;
+}

--- a/ffi/include/coupe.h
+++ b/ffi/include/coupe.h
@@ -1,0 +1,421 @@
+#ifndef COUPE_H
+#define COUPE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Return type for coupe algorithms.
+ *
+ * You may use `coupe_strerror()` to print a user-friendly message relative to a
+ * given error.
+ */
+enum coupe_err {
+	/**
+	 * Everything is fine, no error happened.
+	 */
+	COUPE_ERR_OK,
+	/**
+	 * Coupe failed to allocate something and aborted.
+	 */
+	COUPE_ERR_ALLOC,
+	/**
+	 * Coupe encountered a bug and crashed.
+	 */
+	COUPE_ERR_CRASH,
+	/**
+	 * Either the dimension is invalid (e.g. equals zero), or the algorithm
+	 * does not support such dimension (e.g. Hilbert curves are only
+	 * implemented in two dimensions for now).
+	 */
+	COUPE_ERR_BAD_DIMENSION,
+	/**
+	 * The algorithm does not support a given type.
+	 */
+	COUPE_ERR_BAD_TYPE,
+	/**
+	 * An bi-partitioning algorithm has been fed a partition with more than
+	 * two parts.
+	 */
+	COUPE_ERR_BIPART_ONLY,
+	/**
+	 * Data sets passed to an algorithm don't have the same number of
+	 * elements.
+	 */
+	COUPE_ERR_LEN_MISMATCH,
+	/**
+	 * No partition matching the given constraints have been found.
+	 */
+	COUPE_ERR_NOT_FOUND,
+	/**
+	 * Input contains negative values and such values are not supported.
+	 */
+	COUPE_ERR_NEG_VALUES,
+};
+/**
+ * A descriptive message associated with the given error code.
+ *
+ * The result is a completely static, nul-terminated string and doesn't need to
+ * be deallocated.
+ */
+const char *coupe_strerror(enum coupe_err err);
+
+/**
+ * A data set, used to feed values to algorithms.
+ *
+ * Several types of data sets can be constructed, depending on your needs:
+ *
+ * - `coupe_data_array()` uses a plain contiguous array of values,
+ * - `coupe_data_constant()` repeats the same value a certain amount of times,
+ * - `coupe_data_fn()` calls a function for each value as needed.
+ */
+typedef struct coupe_data coupe_data;
+/**
+ * Data types.
+ *
+ * Some algorithms can be fed vertex weights and edge weights of different
+ * types.  You'll have to see what they support individually.
+ *
+ * Data sets' elements are expected to match the type given with this enum and,
+ * depending on the context, sometimes several values have to be fed for each
+ * item.  More info on individual algorithms.
+ */
+enum coupe_type {
+	/** `int` */
+	COUPE_INT,
+	/** `int64_t` */
+	COUPE_INT64,
+	/** `double` */
+	COUPE_DOUBLE,
+};
+/**
+ * Free the memory used by the given data set.
+ *
+ * This function:
+ *
+ * - can be called with a NULL pointer,
+ * - can only be called once on the same data set,
+ * - does not free any memory the data set points to (e.g. pointers passed to
+ *   `coupe_data_array` and `coupe_data_constant`),
+ * - cannot be called while an algorithm is running on the data set.
+ */
+void coupe_data_free(coupe_data *data);
+/**
+ * A data set that uses values from a contiguous array.
+ *
+ * This function returns a data set, which is used to feed numbers and points
+ * to coupe's algorithms.  These values must be ordered and their order must
+ * match those of the given `partition` arrays (see `coupe_hilbert()` for
+ * example).
+ *
+ * The data set returned by this function retrieves values from the contiguous
+ * array `data`, which must uphold the following constraints:
+ *
+ * - `data` must be at least of length `len`,
+ * - `data` must be available during the lifetime of the data set, and
+ * - it must be possible to access `data` from several threads at the same time.
+ *
+ * This data set can be used several times and so concurrently.  When unused, it
+ * can be freed with `coupe_data_free()`.
+ *
+ * This function returns NULL on allocation failure.
+ */
+coupe_data *coupe_data_array(uintptr_t len, enum coupe_type type, const void *data);
+/**
+ * A data set that copies the same value a given amount of times.
+ *
+ * This function returns a data set, which is used to feed numbers and points
+ * to coupe's algorithms.  These values must be ordered and their order must
+ * match those of the given `partition` arrays (see `coupe_greedy()` for
+ * example).
+ *
+ * The data set returned by this function copies the value beind the given
+ * pointer, which must uphold the following constraints:
+ *
+ * - `value` must be available during the lifetime of the data set, and
+ * - it must be possible to access `value` from several threads at the same time.
+ *
+ * This data set can be used several times and so concurrently.  When unused, it
+ * can be freed with `coupe_data_free()`.
+ *
+ * This function returns NULL on allocation failure.
+ */
+coupe_data *coupe_data_constant(uintptr_t len, enum coupe_type type, const void *value);
+/**
+ * A data set that calls a function to retrieve values.
+ *
+ * This function returns a data set, which is used to feed numbers and points
+ * to coupe's algorithms.  These values must be ordered and their order must
+ * match those of the given `partition` arrays (see `coupe_rcb()` for
+ * example).
+ *
+ * The data set returned by this function retrieves values by calling the given
+ * callback `i_th` as needed.  This callback accepts two arguments:
+ *
+ * - `const void *context`, which is set to the same value as the `context`
+ *   given in `coupe_data_fn`,
+ * - `uintptr_t index`, which is the index of the element to be retrieved.
+ *
+ * The callback `i_th` must assume the following conditions:
+ *
+ * - it must not assume the order in which it is called. For example, an
+ *   algorithm might do this:
+ *
+ *   ```
+ *	   i_th(context, 0);
+ *	   i_th(context, 4572);
+ *	   i_th(context, 19);
+ *   ```
+ *
+ * - `i_th(context, index)` must be valid for all values of `index` between 0
+ *   (inclusive) and `len` (exclusive),
+ * - some values might not be retrieved,
+ * - some values might be retrieved more than once,
+ * - `i_th` might be called from several threads at a time, this means access to
+ *   `context` must be thread-safe, and is why it is sealed by a const pointer.
+ *
+ * This data set can be used several times and so concurrently.  When unused, it
+ * can be freed with `coupe_data_free()`.
+ *
+ * This function returns NULL on allocation failure.
+ */
+coupe_data *coupe_data_fn(const void *context, uintptr_t len,
+		enum coupe_type type, void *(*i_th)(const void *, uintptr_t));
+
+/**
+ * Adjacency structure for use with topologic algorithms.
+ *
+ * This type can be constructed in several ways:
+ *
+ * - `coupe_adjncy_csr()` uses an adjacency matrix in the CSR format, in the
+ *   same way as METIS,
+ * - `coupe_adjncy_csr_unchecked()` is the same, except the matrix structure is
+ *   not checked at runtime.
+ */
+typedef struct coupe_adjncy coupe_adjncy;
+/**
+ * Free the memory used by the given adjacency structure.
+ *
+ * This function:
+ *
+ * - can be called with a NULL pointer,
+ * - can only be called once on the same structure,
+ * - does not free any memory it points to (e.g. the actual CSR arrays),
+ * - cannot be called while an algorithm is using it.
+ */
+void coupe_adjncy_free(coupe_adjncy *adjncy);
+/**
+ * An adjacency matrix in the CSR format.
+ *
+ * The following properties are expected:
+ *
+ * - `xadj` is a contiguous array of `size + 1` elements,
+ * - `adjncy` is a contiguous array of N elements, where N is the last element
+ *   of `xadj`,
+ * - `data` is a contiguous array of N elements, where N is the last element
+ *   of `xadj`,
+ * - all given pointers are accessible concurrently from multiple threads.
+ *
+ * This function does the following checks on the adjacency matrix structure and
+ * returns NULL on failure:
+ *
+ * - `xadj` must be sorted,
+ * - elements of `xadj` must not exceed `UINTPTR_MAX / 2`,
+ * - `adjncy[xadj[i]..xadj[i+1]]` must be sorted for each `i`,
+ * - elements of `adjncy` must be between 0 (inclusive) and `size` (exclusive).
+ *
+ * This adjacency structure can be used several times and so concurrently.  When
+ * unused, it can be freed with `coupe_adjncy_free()`.
+ *
+ * This function returns NULL on allocation failure.
+ */
+coupe_adjncy *coupe_adjncy_csr(uintptr_t size,
+		const uintptr_t *xadj, const uintptr_t *adjncy,
+		enum coupe_type data_type, const void *data);
+/**
+ * An adjacency matrix in the CSR format (unchecked constructor).
+ *
+ * See the documentation of `coupe_adjncy_csr()` for details.
+ *
+ * This function does not check the adjacency matrix structure.  It is up to the
+ * user to ensure all invariants are met.
+ */
+coupe_adjncy *coupe_adjncy_csr_unchecked(uintptr_t size,
+		const uintptr_t *xadj, const uintptr_t *adjncy,
+		enum coupe_type data_type, const void *data);
+
+/************************/
+/* Geometric algorithms */
+/************************/
+
+/**
+ * Algorithm: Recursive Coordinate Biscection.
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.Rcb.html> for a description of
+ * the algorithm. The meaning of the parameters are explained below the example.
+ *
+ * This function returns an error for cases covered by #coupe_err:
+ * - `dimension` must be 2 or 3,
+ * - `points` and `weights` must hold the same number of elements.
+ *
+ * This function also assumes the following invariant is met:
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of either data set.
+ *
+ * The result is stored in `partition`.
+ *
+ * @note
+ * This function might return #COUPE_ERR_NOT_FOUND.  It means one of the splits
+ * did not meet the input tolerance.  It is possible, however, that the overall
+ * imbalance still is within bounds.  It is also possible of the contrary: the
+ * overall imbalance might be out of bounds without RCB returning an error.
+ */
+enum coupe_err coupe_rcb(uintptr_t *partition, uintptr_t dimension,
+		const coupe_data *points, const coupe_data *weights,
+		uintptr_t iter_count, double tolerance);
+/**
+ * Algorithm: Recursive Inertial Biscection.
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.Rib.html> for a description of
+ * the algorithm. The meaning of the parameters are explained below the example.
+ *
+ * See the documentation of `coupe_rcb()` for details.
+ *
+ * @note
+ * This algorithm does not fully support data sets yet.  If either `points` or
+ * `weights` are not made from the `coupe_data_array()`, they are copied into a
+ * newly allocated array.
+ */
+enum coupe_err coupe_rib(uintptr_t *partition, uintptr_t dimension,
+		const coupe_data *points, const coupe_data *weights,
+		uintptr_t iter_count, double tolerance);
+/**
+ * Algorithm: Hilbert space-filling curve
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.HilbertCurve.html> for a
+ * description of the algorithm. The meaning of the parameters are explained
+ * below the example.
+ *
+ * This function returns an error for cases covered by #coupe_err:
+ * - `points` and `weights` must hold the same number of elements,
+ * - `order` must be below 64.
+ *
+ * This function also assumes the following invariants are met:
+ * - `points` are in 2D,
+ * - `weights` are of type `double`,
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of either data set.
+ *
+ * The result is stored in `partition`.
+ *
+ * @note
+ * This algorithm does not fully support data sets yet.  If either `points` or
+ * `weights` are not made from the `coupe_data_array()`, they are copied into a
+ * newly allocated array.
+ */
+enum coupe_err coupe_hilbert(uintptr_t *partition,
+		const coupe_data *points,
+		const coupe_data *weights,
+		uintptr_t part_count, uint32_t order);
+
+/**********************************/
+/* Number-partitioning algorithms */
+/**********************************/
+
+/**
+ * Algorithm: Greedy number partitioning algorithm
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.Greedy.html> for a description
+ * of the algorithm. The meaning of the parameters are explained below the
+ * example.
+ *
+ * This function also assumes the following invariants are met:
+ * - floating point `weights` are not NaN,
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of the weight data set.
+ *
+ * The result is stored in `partition`.
+ */
+enum coupe_err coupe_greedy(uintptr_t *partition, const coupe_data *weights,
+		uintptr_t part_count);
+/**
+ * Algorithm: Karmarkar-Karp
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.KarmarkarKarp.html> for a
+ * description of the algorithm. The meaning of the parameters are explained
+ * below the example.
+ *
+ * This function returns an error for cases covered by `enum coupe_err`:
+ * - `weight_type` can be either type.
+ *
+ * This function also assumes the following invariants are met:
+ * - floating point `weights` are not NaN,
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of the weight data set.
+ *
+ * The result is stored in `partition`.
+ */
+enum coupe_err coupe_karmarkar_karp(uintptr_t *partition, const coupe_data *weights,
+		uintptr_t part_count);
+/**
+ * Algorithm: Complete Karmarkar-Karp
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.CompleteKarmarkarKarp.html>
+ * for a description of the algorithm. The meaning of the parameters are
+ * explained below the example.
+ *
+ * This function also assumes the following invariants are met:
+ * - floating point `weights` are not NaN,
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of the weight data set.
+ *
+ * The result is stored in `partition`.
+ */
+enum coupe_err coupe_karkarkar_karp_complete(uintptr_t *partition, const coupe_data *weights,
+		double tolerance);
+
+/************************/
+/* Topologic algorithms */
+/************************/
+
+/**
+ * Algorithm: Fiduccia-Mattheyses
+ *
+ * See <https://docs.rs/coupe/latest/coupe/struct.FiducciaMattheyses.html> for a
+ * description of the algorithm. The meaning of the parameters are explained
+ * below the example.
+ *
+ * This function returns an error for cases covered by #coupe_err:
+ * - there cannot be more than two parts,
+ * - `adjncy` must be of type #COUPE_INT64.
+ *
+ * This function also assumes the following invariants are met:
+ * - floating point `weights` are not NaN,
+ * - `partition` points to a contiguous array of N `uintptr_t` elements, where N
+ *   is the size of either the weight data set or the adjacency structure,
+ * - the elements of `partition` must start from zero and must be continuous:
+ *   the number of parts is taken from the maximum of this array, plus one.
+ *
+ * The result is stored in `partition`.
+ *
+ * @note
+ * - zero values for `max_passes` and `max_moves_per_pass` are interpreted as
+ *   abscence of value (no limit on the number of passes or moves per pass),
+ *   while zero values for `max_bad_moves_in_a_row` prevents the use of bad
+ *   moves,
+ * - if `max_imbalance` is negative, it will be set to the imbalance of the
+ *   input partition.
+ */
+enum coupe_err coupe_fiduccia_mattheyses(uintptr_t *partition,
+		const coupe_adjncy *adjncy, const coupe_data *weights,
+		uintptr_t max_passes, uintptr_t max_moves_per_pass,
+		double max_imbalance, uintptr_t max_bad_moves_in_a_row);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ffi/src/data.rs
+++ b/ffi/src/data.rs
@@ -1,0 +1,290 @@
+use rayon::iter::IntoParallelIterator as _;
+use rayon::iter::IntoParallelRefIterator as _;
+use rayon::iter::ParallelExtend as _;
+use rayon::iter::ParallelIterator as _;
+use std::borrow::Cow;
+use std::collections::TryReserveError;
+use std::ffi::c_void;
+use std::slice;
+
+#[derive(Clone, Copy, PartialEq)]
+#[repr(C)]
+pub enum Type {
+    Int,
+    Int64,
+    Double,
+}
+
+pub struct Constant {
+    pub len: usize,
+    pub type_: Type,
+    pub value: *const c_void,
+}
+
+impl Constant {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub unsafe fn to_slice<T>(&self) -> Result<Vec<T>, TryReserveError>
+    where
+        T: Copy,
+    {
+        let mut v = Vec::new();
+        v.try_reserve_exact(self.len)?;
+        let value = *(self.value as *const T);
+        v.resize(self.len, value);
+        Ok(v)
+    }
+
+    pub unsafe fn iter<'a, T>(&'a self) -> impl Iterator<Item = T> + ExactSizeIterator + 'a
+    where
+        T: 'a + Copy,
+    {
+        let value = *(self.value as *const T);
+        (0..self.len).map(move |_| value)
+    }
+
+    pub unsafe fn par_iter<'a, T>(
+        &'a self,
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    where
+        T: 'a + Copy + Send + Sync,
+    {
+        let value = *(self.value as *const T);
+        rayon::iter::repeatn(value, self.len)
+    }
+}
+
+pub struct Array {
+    pub len: usize,
+    pub type_: Type,
+    pub array: *const c_void,
+}
+
+impl Array {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub unsafe fn to_slice<'a, T>(&'a self) -> &'a [T]
+    where
+        T: 'a,
+    {
+        slice::from_raw_parts(self.array as *const T, self.len)
+    }
+
+    pub unsafe fn iter<'a, T>(&'a self) -> impl Iterator<Item = T> + ExactSizeIterator + 'a
+    where
+        T: 'a + Copy,
+    {
+        slice::from_raw_parts(self.array as *const T, self.len)
+            .iter()
+            .cloned()
+    }
+
+    pub unsafe fn par_iter<'a, T>(
+        &'a self,
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    where
+        T: 'a + Copy + Send + Sync,
+    {
+        slice::from_raw_parts(self.array as *const T, self.len)
+            .par_iter()
+            .cloned()
+    }
+}
+
+pub struct Fn {
+    pub len: usize,
+    pub type_: Type,
+    pub context: *const c_void,
+    pub i_th: extern "C" fn(*const c_void, usize) -> *const c_void,
+}
+
+unsafe impl Send for Fn {}
+unsafe impl Sync for Fn {}
+
+impl Fn {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub unsafe fn to_slice<T>(&self) -> Result<Vec<T>, TryReserveError>
+    where
+        T: Copy + Send,
+    {
+        let mut v = Vec::new();
+        v.try_reserve_exact(self.len)?;
+        v.par_extend(self.par_iter::<T>());
+        Ok(v)
+    }
+
+    pub unsafe fn iter<'a, T>(&'a self) -> impl Iterator<Item = T> + ExactSizeIterator + 'a
+    where
+        T: 'a + Copy,
+    {
+        (0..self.len).map(|i| {
+            let ptr = (self.i_th)(self.context, i) as *const T;
+            *ptr
+        })
+    }
+
+    pub unsafe fn par_iter<'a, T>(
+        &'a self,
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    where
+        T: 'a + Copy + Send,
+    {
+        (0..self.len).into_par_iter().map(|i| {
+            let ptr = (self.i_th)(self.context, i) as *const T;
+            *ptr
+        })
+    }
+}
+
+pub enum Data {
+    Array(Array),
+    Constant(Constant),
+    Fn(Fn),
+}
+
+impl Data {
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Array(iter) => iter.len(),
+            Self::Constant(iter) => iter.len(),
+            Self::Fn(iter) => iter.len(),
+        }
+    }
+
+    pub unsafe fn to_slice<T>(&self) -> Result<Cow<'_, [T]>, TryReserveError>
+    where
+        T: Copy + Send,
+    {
+        Ok(match self {
+            Self::Array(iter) => Cow::from(iter.to_slice()),
+            Self::Constant(iter) => Cow::from(iter.to_slice()?),
+            Self::Fn(iter) => Cow::from(iter.to_slice()?),
+        })
+    }
+
+    pub fn type_(&self) -> Type {
+        match self {
+            Self::Array(iter) => iter.type_,
+            Self::Constant(iter) => iter.type_,
+            Self::Fn(iter) => iter.type_,
+        }
+    }
+}
+
+/// Replacement for `Data::iter` since you can't have `Box<dyn Trait1 + Trait2>`
+/// yet.
+///
+/// TODO find a way to not use a macro
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let i = coupe_data_constant(5, 0xDEADBEEF);
+/// let v = with_iter!(i, f64, {
+///     i.map(|f| f.ceil()).collect::<Vec<f64>>()
+/// });
+/// println!("{v:?}");
+/// ```
+#[macro_export]
+macro_rules! with_iter {
+    ( $iter:ident, $t:ty, $do:block ) => {
+        match $iter {
+            crate::data::Data::Array($iter) => {
+                let $iter = $iter.iter::<$t>();
+                $do
+            }
+            crate::data::Data::Constant($iter) => {
+                let $iter = $iter.iter::<$t>();
+                $do
+            }
+            crate::data::Data::Fn($iter) => {
+                let $iter = $iter.iter::<$t>();
+                $do
+            }
+        }
+    };
+    ( $iter:ident, $do:block ) => {
+        match $iter.type_() {
+            crate::data::Type::Int => with_iter!($iter, std::os::raw::c_int, $do),
+            crate::data::Type::Int64 => with_iter!($iter, i64, $do),
+            crate::data::Type::Double => with_iter!($iter, f64, $do),
+        }
+    };
+}
+
+/// Replacement for `Data::par_iter` since
+/// `rayon::iter::IndexedParallelIterator` cannot be made into a trait object.
+///
+/// TODO find a way to not use a macro
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let i = coupe_data_array(5, 0xDEADBEEF);
+/// let v = with_par_iter!(i, f64, {
+///     i.map(|f| f.ceil()).collect::<Vec<f64>>()
+/// });
+/// println!("{v:?}");
+/// ```
+#[macro_export]
+macro_rules! with_par_iter {
+    ( $iter:ident, $t:ty, $do:block ) => {
+        match $iter {
+            crate::data::Data::Array($iter) => {
+                let $iter = $iter.par_iter::<$t>();
+                $do
+            }
+            crate::data::Data::Constant($iter) => {
+                let $iter = $iter.par_iter::<$t>();
+                $do
+            }
+            crate::data::Data::Fn($iter) => {
+                let $iter = $iter.par_iter::<$t>();
+                $do
+            }
+        }
+    };
+    ( $iter:ident, $do:block ) => {
+        match $iter.type_() {
+            crate::data::Type::Int => with_par_iter!($iter, std::os::raw::c_int, $do),
+            crate::data::Type::Int64 => with_par_iter!($iter, i64, $do),
+            crate::data::Type::Double => with_par_iter!($iter, f64, $do),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! with_slice {
+    ( $iter:ident, $do:block ) => {
+        match $iter.type_() {
+            crate::data::Type::Int => {
+                let $iter = match $iter.to_slice::<std::os::raw::c_int>() {
+                    Ok(v) => v,
+                    Err(_) => return Error::Alloc,
+                };
+                $do
+            }
+            crate::data::Type::Int64 => {
+                let $iter = match $iter.to_slice::<i64>() {
+                    Ok(v) => v,
+                    Err(_) => return Error::Alloc,
+                };
+                $do
+            }
+            crate::data::Type::Double => {
+                let $iter = match $iter.to_slice::<f64>() {
+                    Ok(v) => v,
+                    Err(_) => return Error::Alloc,
+                };
+                $do
+            }
+        }
+    };
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,510 @@
+#![allow(clippy::missing_safety_doc)] // See include/coupe.h
+
+use crate::data::Data;
+use crate::data::Type;
+use coupe::Partition as _;
+use coupe::Point2D;
+use coupe::PointND;
+use coupe::Real;
+use nalgebra::allocator::Allocator;
+use nalgebra::ArrayStorage;
+use nalgebra::Const;
+use nalgebra::DefaultAllocator;
+use nalgebra::DimDiff;
+use nalgebra::DimSub;
+use nalgebra::ToTypenum;
+use std::ffi::c_void;
+use std::mem;
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+use std::ptr;
+use std::slice;
+
+#[macro_use]
+mod data;
+
+fn box_try_new<T>(value: T) -> Option<Box<T>>
+where
+    T: std::panic::UnwindSafe,
+{
+    // TODO replace with [Box::try_new] once stabilised.
+    std::panic::catch_unwind(|| Some(Box::new(value))).unwrap_or(None)
+}
+
+#[repr(C)]
+pub enum Error {
+    Ok,
+    Alloc,
+    Crash,
+    BadDimension,
+    BadType,
+    BipartOnly,
+    LenMismatch,
+    NotFound,
+    NegValues,
+}
+
+impl From<coupe::Error> for Error {
+    fn from(err: coupe::Error) -> Self {
+        match err {
+            coupe::Error::NotFound => Self::NotFound,
+            coupe::Error::NegativeValues => Self::NegValues,
+            coupe::Error::BiPartitioningOnly => Self::BipartOnly,
+            coupe::Error::InputLenMismatch { .. } => Self::LenMismatch,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Wrapper around [std::panic::catch_unwind] that returns [Error::Crash] on
+/// panic.
+fn catch_unwind<F>(f: F) -> Error
+where
+    F: FnOnce() -> Error + std::panic::UnwindSafe,
+{
+    std::panic::catch_unwind(f).unwrap_or(Error::Crash)
+}
+
+#[no_mangle]
+pub extern "C" fn coupe_strerror(err: Error) -> *const c_char {
+    match err {
+        Error::Ok => {
+            static MSG: &[u8] = b"success\0";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::Alloc => {
+            static MSG: &[u8] = b"allocation failed\0";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::Crash => {
+            static MSG: &[u8] = b"coupe encountered a bug and crashed\0";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::BadDimension => {
+            static MSG: &[u8] = b"this algorithm does not support the given mesh dimension";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::BadType => {
+            static MSG: &[u8] = b"this algorithm does not support the given type";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::BipartOnly => {
+            static MSG: &[u8] = b"this algorithm does not support k-way partitioning\0";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::LenMismatch => {
+            static MSG: &[u8] = b"input iters (e.g. weights and points) don't have the same length";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::NotFound => {
+            static MSG: &[u8] = b"no partition has been found for the given constraints\0";
+            MSG.as_ptr() as *const c_char
+        }
+        Error::NegValues => {
+            static MSG: &[u8] = b"this algorithm does not support negative values\0";
+            MSG.as_ptr() as *const c_char
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_data_free(data: *mut Data) {
+    if !data.is_null() {
+        let data = Box::from_raw(data);
+        mem::drop(data);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn coupe_data_array(len: usize, type_: Type, array: *const c_void) -> *mut Data {
+    let data = Data::Array(data::Array { len, type_, array });
+    match box_try_new(data) {
+        Some(v) => Box::into_raw(v),
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn coupe_data_constant(len: usize, type_: Type, value: *const c_void) -> *mut Data {
+    let data = Data::Constant(data::Constant { len, type_, value });
+    match box_try_new(data) {
+        Some(v) => Box::into_raw(v),
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn coupe_data_fn(
+    context: *const c_void,
+    len: usize,
+    type_: Type,
+    i_th: extern "C" fn(*const c_void, usize) -> *const c_void,
+) -> *mut Data {
+    let data = Data::Fn(data::Fn {
+        len,
+        type_,
+        context,
+        i_th,
+    });
+    match box_try_new(data) {
+        Some(v) => Box::into_raw(v),
+        None => ptr::null_mut(),
+    }
+}
+
+pub enum Adjncy<'a> {
+    Int(sprs::CsMatView<'a, c_int>),
+    Int64(sprs::CsMatView<'a, i64>),
+    Double(sprs::CsMatView<'a, f64>),
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_adjncy_free(adjncy: *mut Adjncy) {
+    if !adjncy.is_null() {
+        let adjncy = Box::from_raw(adjncy);
+        mem::drop(adjncy);
+    }
+}
+
+unsafe fn adjncy_csr_unchecked(
+    size: usize,
+    xadj: *const usize,
+    adjncy: *const usize,
+    data_type: Type,
+    data: *const c_void,
+) -> Adjncy<'static> {
+    let xadj = slice::from_raw_parts(xadj, size + 1);
+    let adjncy = slice::from_raw_parts(adjncy, xadj[xadj.len() - 1]);
+    match data_type {
+        Type::Int => {
+            let data = slice::from_raw_parts(data as *const c_int, adjncy.len());
+            let matrix =
+                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            Adjncy::Int(matrix)
+        }
+        Type::Int64 => {
+            let data = slice::from_raw_parts(data as *const i64, adjncy.len());
+            let matrix =
+                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            Adjncy::Int64(matrix)
+        }
+        Type::Double => {
+            let data = slice::from_raw_parts(data as *const f64, adjncy.len());
+            let matrix =
+                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            Adjncy::Double(matrix)
+        }
+    }
+}
+
+fn adjncy_ptr(adjacency: Adjncy<'_>) -> *mut Adjncy<'_> {
+    match box_try_new(adjacency) {
+        Some(v) => Box::into_raw(v),
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_adjncy_csr(
+    size: usize,
+    xadj: *const usize,
+    adjncy: *const usize,
+    data_type: Type,
+    data: *const c_void,
+) -> *mut Adjncy<'static> {
+    let adjacency = adjncy_csr_unchecked(size, xadj, adjncy, data_type, data);
+    match adjacency {
+        Adjncy::Int(matrix) => {
+            if matrix.check_compressed_structure().is_err() {
+                return ptr::null_mut();
+            }
+        }
+        Adjncy::Int64(matrix) => {
+            if matrix.check_compressed_structure().is_err() {
+                return ptr::null_mut();
+            }
+        }
+        Adjncy::Double(matrix) => {
+            if matrix.check_compressed_structure().is_err() {
+                return ptr::null_mut();
+            }
+        }
+    }
+    adjncy_ptr(adjacency)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_adjncy_csr_unchecked(
+    size: usize,
+    xadj: *const usize,
+    adjncy: *const usize,
+    data_type: Type,
+    data: *const c_void,
+) -> *mut Adjncy<'static> {
+    let adjacency = adjncy_csr_unchecked(size, xadj, adjncy, data_type, data);
+    adjncy_ptr(adjacency)
+}
+
+unsafe fn coupe_rcb_d<const D: usize>(
+    partition: &mut [usize],
+    points: &Data,
+    weights: &Data,
+    mut algo: coupe::Rcb,
+) -> Error {
+    let res = with_par_iter!(points, PointND<D>, {
+        with_par_iter!(weights, { algo.partition(partition, (points, weights)) })
+    });
+    match res {
+        Ok(_) => Error::Ok,
+        Err(err) => Error::from(err),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_rcb(
+    partition: *mut usize,
+    dimension: usize,
+    points: *const Data,
+    weights: *const Data,
+    iter_count: usize,
+    tolerance: f64,
+) -> Error {
+    let points = &*points;
+    let weights = &*weights;
+
+    let element_count = points.len();
+    if element_count != weights.len() {
+        return Error::LenMismatch;
+    }
+
+    let algo = coupe::Rcb {
+        iter_count,
+        tolerance,
+        ..Default::default()
+    };
+
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+        match dimension {
+            2 => coupe_rcb_d::<2>(partition, points, weights, algo),
+            3 => coupe_rcb_d::<3>(partition, points, weights, algo),
+            _ => Error::BadDimension,
+        }
+    })
+}
+
+unsafe fn coupe_rib_d<const D: usize>(
+    partition: &mut [usize],
+    points: &Data,
+    weights: &Data,
+    mut algo: coupe::Rib,
+) -> Error
+where
+    Const<D>: DimSub<Const<1>> + ToTypenum,
+    DefaultAllocator: Allocator<f64, Const<D>, Const<D>, Buffer = ArrayStorage<f64, D, D>>
+        + Allocator<f64, DimDiff<Const<D>, Const<1>>>,
+{
+    let points = match points.to_slice::<PointND<D>>() {
+        Ok(v) => v,
+        Err(_) => return Error::Alloc,
+    };
+    let res = with_par_iter!(weights, {
+        algo.partition(partition, (points.as_ref(), weights))
+    });
+    match res {
+        Ok(_) => Error::Ok,
+        Err(err) => Error::from(err),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_rib(
+    partition: *mut usize,
+    dimension: usize,
+    points: *const Data,
+    weights: *const Data,
+    iter_count: usize,
+    tolerance: f64,
+) -> Error {
+    let points = &*points;
+    let weights = &*weights;
+
+    let element_count = points.len();
+    if element_count != weights.len() {
+        return Error::LenMismatch;
+    }
+
+    let algo = coupe::Rib {
+        iter_count,
+        tolerance,
+    };
+
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+        match dimension {
+            2 => coupe_rib_d::<2>(partition, points, weights, algo),
+            3 => coupe_rib_d::<3>(partition, points, weights, algo),
+            _ => Error::BadDimension,
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_hilbert(
+    partition: *mut usize,
+    points: *const Data,
+    weights: *const Data,
+    part_count: usize,
+    order: u32,
+) -> Error {
+    let points = &*points;
+    let weights = &*weights;
+
+    let element_count = points.len();
+    if element_count != weights.len() {
+        return Error::LenMismatch;
+    }
+    if weights.type_() != Type::Double {
+        return Error::BadType;
+    }
+
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+
+        let points = match points.to_slice::<Point2D>() {
+            Ok(v) => v,
+            Err(_) => return Error::Alloc,
+        };
+        let weights = match weights.to_slice::<f64>() {
+            Ok(v) => v,
+            Err(_) => return Error::Alloc,
+        };
+
+        let res = coupe::HilbertCurve { part_count, order }.partition(partition, (points, weights));
+
+        match res {
+            Ok(()) => Error::Ok,
+            Err(_) => Error::NotFound, // TODO use a proper error code
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_greedy(
+    partition: *mut usize,
+    weights: *const Data,
+    part_count: usize,
+) -> Error {
+    let weights = &*weights;
+    let element_count = weights.len();
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+        let mut algo = coupe::Greedy { part_count };
+        match with_iter!(weights, { algo.partition(partition, weights) }) {
+            Ok(()) => Error::Ok,
+            Err(err) => Error::from(err),
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_karmarkar_karp(
+    partition: *mut usize,
+    weights: *const Data,
+    part_count: usize,
+) -> Error {
+    let weights = &*weights;
+    let element_count = weights.len();
+
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+
+        let mut algo = coupe::KarmarkarKarp { part_count };
+
+        let res = match weights.type_() {
+            Type::Int => {
+                with_iter!(weights, c_int, { algo.partition(partition, weights) })
+            }
+            Type::Int64 => {
+                with_iter!(weights, i64, { algo.partition(partition, weights) })
+            }
+            Type::Double => {
+                with_iter!(weights, Real, { algo.partition(partition, weights) })
+            }
+        };
+
+        match res {
+            Ok(()) => Error::Ok,
+            Err(err) => Error::from(err),
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_karmarkar_karp_complete(
+    partition: *mut usize,
+    weights: *const Data,
+    tolerance: f64,
+) -> Error {
+    let weights = &*weights;
+    let element_count = weights.len();
+    catch_unwind(|| {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+        let mut algo = coupe::CompleteKarmarkarKarp { tolerance };
+        match with_iter!(weights, { algo.partition(partition, weights) }) {
+            Ok(()) => Error::Ok,
+            Err(err) => Error::from(err),
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn coupe_fiduccia_mattheyses(
+    partition: *mut usize,
+    adjncy: *const Adjncy<'_>,
+    weights: *const Data,
+    max_passes: usize,
+    max_moves_per_pass: usize,
+    max_imbalance: f64,
+    max_bad_moves_in_a_row: usize,
+) -> Error {
+    let weights = &*weights;
+    let element_count = weights.len();
+
+    let mut algo = coupe::FiducciaMattheyses {
+        max_passes: if max_passes == 0 {
+            None
+        } else {
+            Some(max_passes)
+        },
+        max_moves_per_pass: if max_moves_per_pass == 0 {
+            None
+        } else {
+            Some(max_moves_per_pass)
+        },
+        max_imbalance: if max_imbalance <= 0.0 {
+            None
+        } else {
+            Some(max_imbalance)
+        },
+        max_bad_move_in_a_row: max_bad_moves_in_a_row,
+    };
+
+    let adjacency = match &*adjncy {
+        Adjncy::Int64(matrix) => *matrix,
+        _ => return Error::BadType,
+    };
+
+    catch_unwind(move || {
+        let partition = slice::from_raw_parts_mut(partition, element_count);
+
+        let res = with_slice!(weights, {
+            algo.partition(partition, (adjacency, weights.as_ref()))
+        });
+
+        match res {
+            Ok(_) => Error::Ok, // TODO use metadata
+            Err(err) => Error::from(err),
+        }
+    })
+}


### PR DESCRIPTION
So that coupe can be used from most languages, not just rust.

The C interface follows this pattern:

A `struct coupe_iter` opaque type can be constructed in several ways, to
allow the user to feed coupe elements in different ways.

For example, if the user has an array of weights, they can use:

    struct coupe_iter *w = coupe_iter_array(weight_count, weights);

or if they don't want to use weights:

    int one = 1;
    struct coupe_iter *w = coupe_iter_constant(weight_count, &one);

(very idiomatic C!  unfortunately for these function to be "generic" the
second argument has to be a `void *`)

and if they have a complex data structure that can be indexed:

    ComplexWeightCollection *coll = /* ... */
    struct coupe_iter *w =
            coupe_iter_fn(coll, weight_count, get_ith_weight);

Algorithms are implemented as functions, that take:
- the partition array,
- some iterators for the points and weights,
- the algorithms parameters.
They return an error if any.  Maybe some error can be returned but the
partition still be populated and valid.

TODO
- [x] Use nightly's `try_new` for `coupe_iter_*` functions:
      https://doc.rust-lang.org/std/boxed/struct.Box.html#method.try_new
- [x] Only RCB is there now, add other geometric algorithms,
- [x] Add topologic algorithms,
- [x] Add number algorithms,
- [x] Update coupe's README.md,
- [x] Expand ffi/README.md,
- [x] resolve TODO in iter.rs,
- [x] Should the number of elements in an iterator be defined as one of its fields (current choice) or outside? The later might be more flexible and intuitive from a C point of view, and there would be no use of `COUPE_ERR_LEN_MISMATCH` then. -> define everything (type/number) inside the iterator.
- [x] Add an example or two (let's add one more),
- [ ] Add room for multi-criteria runs,
- [x] Put the type with the iter struct,
- [x] Change `coupe_iter` name to something else,
- [x] remove the TODO list from the first commit and update it with the new API.

Depends on #130