### PR TITLE
try and reduce the number of panics

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -31,6 +31,7 @@ pub use multi_jagged::MultiJagged;
 pub use recursive_bisection::Rcb;
 pub use recursive_bisection::RcbWeight;
 pub use recursive_bisection::Rib;
+use std::collections::TryReserveError;
 pub use vn::VnBest;
 pub use vn::VnBestWeight;
 pub use vn::VnFirst;
@@ -41,6 +42,9 @@ pub use z_curve::ZCurve;
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// An allocation failed, out of memory error.
+    Alloc,
+
     /// No partition that matches the given criteria could been found.
     NotFound,
 
@@ -63,6 +67,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Alloc => write!(f, "out of memory"),
             Self::NotFound => write!(f, "no partition found"),
             Self::InputLenMismatch { expected, actual } => write!(
                 f,
@@ -78,6 +83,12 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+impl From<TryReserveError> for Error {
+    fn from(_: TryReserveError) -> Self {
+        Self::Alloc
+    }
+}
 
 fn try_from_f64<T>(f: f64) -> Result<T, Error>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod imbalance;
 mod nextafter;
 mod real;
 pub mod topology;
+mod vec;
 
 pub use crate::algorithms::*;
 pub use crate::geometry::BoundingBox;

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -31,6 +31,8 @@ pub fn edge_cut<T>(adjacency: CsMatView<'_, T>, partition: &[usize]) -> T
 where
     T: Copy + Sum + Send + Sync + PartialEq,
 {
+    debug_assert_eq!(adjacency.shape(), (partition.len(), partition.len()));
+
     let indptr = adjacency.indptr().into_raw_storage();
     let indices = adjacency.indices();
     let data = adjacency.data();
@@ -54,6 +56,8 @@ where
 }
 
 pub fn lambda_cut<T>(adjacency: CsMatView<'_, T>, partition: &[usize]) -> usize {
+    debug_assert_eq!(adjacency.shape(), (partition.len(), partition.len()));
+
     let indptr = adjacency.indptr().into_raw_storage();
     let indices = adjacency.indices();
     indptr

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,0 +1,64 @@
+use std::collections::TryReserveError;
+
+/// Extension trait to handle allocation failures on [Vec] operations.
+pub trait VecExt<T> {
+    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>
+    where
+        Self: Sized;
+
+    /// Fallible equivalent of [`vec!`].
+    fn try_filled(value: T, len: usize) -> Result<Self, TryReserveError>
+    where
+        Self: Sized,
+        T: Clone;
+
+    /// Fallible equivalent of [`Vec::push`].
+    fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
+}
+
+impl<T> VecExt<T> for Vec<T> {
+    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>
+    where
+        Self: Sized,
+    {
+        let mut v = Vec::new();
+        v.try_reserve(capacity)?;
+        Ok(v)
+    }
+
+    fn try_filled(value: T, len: usize) -> Result<Self, TryReserveError>
+    where
+        T: Clone,
+    {
+        let mut v = Vec::new();
+        v.try_reserve_exact(len)?;
+        v.resize(len, value);
+        Ok(v)
+    }
+
+    fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
+        self.try_reserve(1)?;
+        self.push(value);
+        Ok(())
+    }
+}
+
+pub trait SliceExt<T> {
+    fn try_to_vec(&self) -> Result<Vec<T>, TryReserveError>
+    where
+        Self: Sized,
+        T: Clone;
+}
+
+impl<T> SliceExt<T> for &[T] {
+    fn try_to_vec(&self) -> Result<Vec<T>, TryReserveError>
+    where
+        Self: Sized,
+        T: Clone,
+    {
+        let mut v = Vec::new();
+        v.try_reserve_exact(self.len())?;
+        v.extend_from_slice(self);
+        Ok(v)
+    }
+}


### PR DESCRIPTION
Mainly through:
- fallible allocations (`try_reserve`),
- helpers around `num::{To,From}Primitive::{to,from}_f64` that return a meaningful error instead of an Option.

Pros:
- return meaningful errors in FFI instead of opaque types with `catch_unwind`,
- errors are caught even if coupe is built with `panic = "abort"`.

Cons:
- FFI will still need `catch_unwind` since some errors might not be caught, and dependencies might panic (rayon especially),
- it's more code to maintain.

TODO
- [ ] move helpers into the root module since imbalance.rs needs them