### PR TITLE
Add Dockerfile And Github Action Triggering Docker Push

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+/benches
+/example
+/target
+/build
+
+# files
+LICENCE*
+*.md
+

--- a/.github/workflows/docker-publish-nightly.yml
+++ b/.github/workflows/docker-publish-nightly.yml
@@ -1,0 +1,74 @@
+name: Nightly Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "coupe",
+            base_image: "rust:latest",
+          }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/lihpc-computational-geometry/${{ matrix.config.name }}
+          labels: |
+            org.opencontainers.image.title=Coupe
+            org.opencontainers.image.description=Coupe Image
+            org.opencontainers.image.vendor=CEA
+          tags: |
+            type=raw,value=nightly
+
+      # Build and push Docker image with Buildx
+      - name: Build and push nightly Docker image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            BASEIMAGE=${{ matrix.config.base_image }}
+            RECIPES_BANCH='main'
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish-nightly.yml
+++ b/.github/workflows/docker-publish-nightly.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@master
+        with:
+          dockerfile: "Dockerfile"
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -64,7 +69,7 @@ jobs:
 
       # Build and push Docker image with Buildx
       - name: Build and push nightly Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             BASEIMAGE=${{ matrix.config.base_image }}

--- a/.github/workflows/docker-publish-nightly.yml
+++ b/.github/workflows/docker-publish-nightly.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           build-args: |
             BASEIMAGE=${{ matrix.config.base_image }}
-            RECIPES_BANCH='main'
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,10 +8,6 @@ name: Docker
 on:
   workflow_dispatch:
     inputs:
-      recipes_branch:
-        description: 'Coupe recipes branch'
-        required: true
-        default: 'main'
       tag_name:
         description: 'Tag name for image'
         required: true
@@ -72,7 +68,6 @@ jobs:
         with:
           build-args: |
             BASEIMAGE=${{ matrix.config.base_image }}
-            RECIPES_BANCH=${{ github.event.inputs.recipes_branch }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      recipes_branch:
+        description: 'Coupe recipes branch'
+        required: true
+        default: 'main'
+      tag_name:
+        description: 'Tag name for image'
+        required: true
+        default: 'main'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "coupe",
+            base_image: "rust:latest",
+          }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/lihpc-computational-geometry/${{ matrix.config.name }}
+          labels: |
+            org.opencontainers.image.title=Coupe
+            org.opencontainers.image.description=Coupe Image
+            org.opencontainers.image.vendor=CEA
+          tags: |
+            type=raw, ${{ github.event.inputs.tag_name }}
+            type=raw, ${{ github.event.inputs.tag_name }}-{{date 'YYYYMMDD'}}
+ 
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            BASEIMAGE=${{ matrix.config.base_image }}
+            RECIPES_BANCH=${{ github.event.inputs.recipes_branch }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             BASEIMAGE=${{ matrix.config.base_image }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG BASEIMAGE=rust:slim-bullseye
+
+# BUILDER PATTERN
+
+FROM $BASEIMAGE AS builder
+
+WORKDIR /builder
+
+COPY . .
+
+RUN apt-get update -y && apt-get install -y libclang-dev libmetis-dev libscotch-dev
+
+ARG BINDGEN_EXTRA_CLANG_ARGS="-I/usr/include/scotch"
+
+RUN cargo install --path tools --root /builder/install
+
+# FINAL IMAGE
+
+FROM debian:bullseye-slim
+
+WORKDIR /coupe
+
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libscotch* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libmetis* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /builder/install/bin /usr/bin
+

--- a/tools/README.md
+++ b/tools/README.md
@@ -136,9 +136,11 @@ docker container run -dit \
     coupe
 
 # Generate a linear weight distribution from an embedded mesh file.
-docker exec coupe_c sh -c 'cat meshes/hole.mesh | weight-gen \
-    --distribution linear,x,0,100 \
-    >shared/hole.linear.weights'
+# Note: option `--integers` can be used to generate integers instead of
+# floating-point numbers.
+docker exec coupe_c sh -c 'weight-gen --distribution linear,x,0,100 \
+    <shared/sample.mesh \
+    >shared/sample.linear.weights'
 
 # Partition the previous mesh and the generated weight distribution into 2 parts.
 # using the Recursive Coordinate Bisection (RCB) algorithm coupled with the
@@ -146,18 +148,18 @@ docker exec coupe_c sh -c 'cat meshes/hole.mesh | weight-gen \
 docker exec coupe_c sh -c 'mesh-part \
     --algorithm rcb,1 \
     --algorithm fm \
-    --mesh meshes/hole.mesh \
-    --weights shared/hole.linear.weights \
-    >shared/hole.linear.rcb-fm.part'
+    --mesh shared/sample.mesh \
+    --weights shared/sample.linear.weights \
+    >shared/sample.linear.rcb-fm.part'
 
 # Merge partition file into MEDIT mesh file and converts it to .svg file.
 docker exec coupe_c sh -c 'apply-part \
-    --mesh meshes/hole.mesh \
-    --partition shared/hole.linear.rcb-fm.part \
-    | medit2svg >shared/hole.rcb-fm.svg'
+    --mesh shared/sample.mesh \
+    --partition shared/sample.linear.rcb-fm.part \
+    | medit2svg >shared/sample.rcb-fm.svg'
 
 # Open the svg file in firefox.
-firefox hole.rcb-fm.svg &
+firefox sample.rcb-fm.svg &
 ```
 
 [intel]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/analyze-performance/code-profiling-scenarios/task-analysis.html#task-analysis_TOP_TASKS


### PR DESCRIPTION
Summary :
- Dockerfile to build a minimal docker image containing coupe bins
- Add meshes exemples
- Add new github action (must be manually triggered)

Pros:
- Usefull for hands-on sessions / paper submissions

TODO:
- [x] Update README.md to show how to run a simple example
- [x] Add automatic nightly publish ?
