### PR TITLE
ffi: do not document rust crate

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [lib]
 name = "coupe"
+doc = false # name conflicts with the rust lib
 crate-type = [
     "cdylib",
     "staticlib",


### PR DESCRIPTION
We want coupe-ffi to have a library named coupe, so that the generated
objects are libcoupe.{a,so}.  However, this makes `cargo doc` fail
because it conflicts with the rust lib.

Since the rust-side of the documentation is not important (there already
is a documented, doxygen-compatible header file), this commit disables
the documentation on this crate.