### PR TITLE
part-bench: change benchmark name format

### DIFF
--- a/tools/report/efficiency
+++ b/tools/report/efficiency
@@ -91,7 +91,7 @@ done >>"$csv"
 max_thread_count=$(echo "$thread_counts" | tail -n1)
 plot_cmds=$(awk -v csv="$csv" "BEGIN{
 	for (i=1; i<ARGC; i++) {
-		gsub(/\_/, \"\\\\_\", ARGV[i])
+		gsub(/_/, \"\\\\_\", ARGV[i])
 		printf \",'%s' using 1:%d title '%s' with linespoints\",csv,i+1,ARGV[i]
 	}
 }" $@)

--- a/tools/src/bin/part-bench/main.rs
+++ b/tools/src/bin/part-bench/main.rs
@@ -117,9 +117,19 @@ fn main_d<const D: usize>(
 
         let weight_file = matches.opt_str("w").unwrap();
         let weight_file = PathBuf::from(weight_file);
-        let weight_file = weight_file.file_stem().unwrap().to_str().unwrap();
+        let mut weight_file = weight_file.file_stem().unwrap().to_str().unwrap();
 
-        format!("{mesh_file}:{weight_file}:{}", algorithm_specs.join(":"))
+        if let Some(wf) = weight_file.strip_prefix(mesh_file) {
+            weight_file = wf;
+            if let Some(wf) = weight_file.strip_prefix('.') {
+                weight_file = wf;
+            }
+        };
+        if weight_file.is_empty() {
+            format!("{mesh_file};{}", algorithm_specs.join(";"))
+        } else {
+            format!("{mesh_file};{weight_file};{}", algorithm_specs.join(";"))
+        }
     };
     if matches.opt_present("e") {
         let max_threads = rayon::current_num_threads();


### PR DESCRIPTION
1. replaced ':' with ';' to work well with metis and scotch algorithms
2. trim the mesh file name from the weight file name, so that

       triangles;triangles.constant;rcb,1

   becomes

       triangles;constant;rcb,1

   and `triangles;triangles;hilbert,2` becomes `triangles;hilbert,2`,
   because benchmark names are limited to 64 bytes by criterion.

Closes #101