### PR TITLE
Faster simple rcb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,15 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,10 +177,7 @@ name = "coupe"
 version = "0.1.0"
 dependencies = [
  "approx",
- "async-lock",
  "criterion",
- "event-listener",
- "futures-lite",
  "gnuplot",
  "itertools",
  "nalgebra",
@@ -369,12 +357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,46 +369,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fastrand"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-core"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-
-[[package]]
-name = "futures-io"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "getopts"
@@ -494,15 +440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -805,12 +742,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "paste"
@@ -1425,12 +1356,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,6 @@ ndarray = "0.15"
 num = "0.4"
 rayon = "1.3"
 tracing = "0.1"
-async-lock = "2"
-event-listener = "2"
-futures-lite = "1"
 rand = "0.8"
 sprs = { version = "0.11", default-features = false, features = ["multi_thread"] }
 

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -3,9 +3,6 @@ use crate::geometry::Mbr;
 use crate::geometry::PointND;
 use crate::partial_cmp;
 use crate::work_share::work_share;
-use async_lock::Mutex;
-use async_lock::MutexGuard;
-use itertools::Itertools as _;
 use nalgebra::allocator::Allocator;
 use nalgebra::ArrayStorage;
 use nalgebra::Const;
@@ -15,35 +12,13 @@ use nalgebra::DimSub;
 use nalgebra::ToTypenum;
 use rayon::prelude::*;
 use std::cmp;
-use std::future::Future;
 use std::iter::Sum;
 use std::mem;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Sub;
-use std::pin::Pin;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-
-#[derive(Default)]
-struct Condvar {
-    event: event_listener::Event,
-}
-
-impl Condvar {
-    pub async fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
-        let listener = self.event.listen();
-        let lock = MutexGuard::source(&guard);
-        mem::drop(guard);
-        listener.await;
-        lock.lock().await
-    }
-
-    pub fn notify_all(&self) {
-        self.event.notify(usize::MAX);
-    }
-}
 
 #[derive(Clone, Debug)]
 struct Item<'p, const D: usize, W> {
@@ -52,537 +27,7 @@ struct Item<'p, const D: usize, W> {
     part: &'p AtomicUsize,
 }
 
-#[derive(Debug, Default)]
-struct IterationData<W> {
-    min: f64,
-    max: f64,
-    sum: W,
-
-    /// Weight on the left of the split target.  The weight on the right can
-    /// be obtained through InitData's sum.
-    left_part_weight: W, // current iteration
-    additional_left_weight: W, // previous iterations
-
-    /// The number of weights on the left of the split target.  The number
-    /// on the right can be obtained through items's length.
-    left_part_count: usize,
-
-    /// The number of weights on the left of max and min.  Used to tell
-    /// whether it is impossible to find a split target that satisfy the
-    /// tolerance, and thus stop the iteration.
-    count_left_max: usize,
-    count_left_min: usize,
-
-    /// Time-to-Live, initialized to the number of threads and decreased on
-    /// every write on min, max and sum, to know when they are initialized.
-    ttl_min_max_sum: usize,
-
-    ttl: usize,
-}
-
-impl<W> IterationData<W>
-where
-    W: Default,
-{
-    pub fn new(thread_count: usize) -> Self {
-        Self {
-            ttl_min_max_sum: thread_count,
-            ..IterationData::default()
-        }
-    }
-}
-
-/// Data shared by all threads
-struct IterationState<W> {
-    c: Condvar,
-    data: Mutex<IterationData<W>>,
-
-    /// whether to stop the computation
-    run: AtomicBool,
-    thread_count: AtomicUsize,
-}
-
-impl<W> IterationState<W>
-where
-    W: Default,
-{
-    fn new(thread_count: usize) -> Self {
-        Self {
-            c: Condvar::default(),
-            data: Mutex::new(IterationData::new(thread_count)),
-            run: AtomicBool::new(true),
-            thread_count: AtomicUsize::new(thread_count),
-        }
-    }
-}
-
-#[tracing::instrument(skip(items))]
-fn apply_part_id<const D: usize, W>(items: &[Item<'_, D, W>], part_id: usize) {
-    for item in items {
-        item.part.store(part_id, Ordering::Relaxed);
-    }
-}
-
-#[tracing::instrument(skip(iter_ctxs))]
-async fn cancel_iterations<W>(iter_ctxs: &[IterationState<W>], iter_count: usize, iter_id: usize) {
-    // We start with iteration `iter_id` and visit all its transitive children,
-    // breadth-first style.
-    // `iter_ctxs` is ordered in such manner that the children of iteration N
-    // are iterations 2N+1 and 2N+2.  Thus, its 2nd-level children are
-    // iterations 4N+3, 4N+4, 4N+5 and 4N+6.  In general, its p-level children
-    // are iterations [2^p*N + 2^p-1; 2^p*N + 2^(p+1)-1[.
-    let mut i = 0; // offset value, ranging from 2^1-1 to 2^((iter_count-1)+1)-1
-    let mut iter_level = 1; // 2^p
-    for _ in 0..iter_count {
-        for _ in 0..iter_level {
-            let ctx = &iter_ctxs[iter_id * iter_level + i];
-            let mut d = ctx.data.lock().await;
-            d.ttl_min_max_sum = d.ttl_min_max_sum.checked_sub(1).unwrap();
-            // We won't participate in the iteration.
-            ctx.thread_count.fetch_sub(1, Ordering::Relaxed);
-            ctx.c.notify_all();
-            i += 1;
-        }
-        iter_level *= 2;
-    }
-}
-
-/// # Panics
-///
-/// This function panics if `items` is empty.
-#[tracing::instrument(skip(ctx, items))]
-async fn compute_min_max<const D: usize, W>(
-    ctx: &IterationState<W>,
-    items: &[Item<'_, D, W>],
-    coord: usize,
-) -> (f64, f64)
-where
-    W: Copy + AddAssign + Sum + std::fmt::Debug,
-{
-    let min_max_span = tracing::info_span!("compute");
-    let enter = min_max_span.enter();
-
-    let partial_sum: W = items.iter().map(|item| item.weight).sum();
-    let (partial_min, partial_max) = items
-        .iter()
-        .map(|item| item.point[coord])
-        .minmax()
-        .into_option()
-        .unwrap(); // Won't panic because items has at least one element.
-
-    mem::drop(enter);
-
-    let mut d = ctx.data.lock().await;
-    if partial_min < d.min {
-        d.min = partial_min;
-    }
-    if d.max < partial_max {
-        d.max = partial_max;
-    }
-    d.sum += partial_sum;
-    d.ttl_min_max_sum = d.ttl_min_max_sum.checked_sub(1).unwrap();
-    if d.ttl_min_max_sum == 0 {
-        ctx.c.notify_all();
-    }
-    while d.ttl_min_max_sum != 0 {
-        d = ctx.c.wait(d).await;
-    }
-    if d.ttl == 0 {
-        // Only set these values once.
-        d.ttl = ctx.thread_count.load(Ordering::Relaxed);
-        d.count_left_max = items.len();
-    }
-
-    tracing::info!(
-        "compute_min_max_sum: min={:?}/{:?}, max={:?}/{:?}, sum={:?}/{:?}",
-        partial_min,
-        d.min,
-        partial_max,
-        d.max,
-        partial_sum,
-        d.sum,
-    );
-
-    (d.min, d.max)
-}
-
-struct SplitResult<'a, 'p, const D: usize, W> {
-    left: &'a mut [Item<'p, D, W>],
-    right: &'a mut [Item<'p, D, W>],
-    left_weight: W,
-}
-
-#[tracing::instrument(skip(items))]
-fn try_split_items<'a, 'p, const D: usize, W>(
-    items: &'a mut [Item<'p, D, W>],
-    coord: usize,
-    split_target: f64,
-) -> SplitResult<'a, 'p, D, W>
-where
-    W: Copy + Sum,
-{
-    let left_count = items
-        .iter()
-        .filter(|item| item.point[coord] < split_target)
-        .count();
-
-    let (left, right) = if left_count == items.len() {
-        items.split_at_mut(items.len())
-    } else {
-        let (left, _, _right_minus_one) = items
-            .select_nth_unstable_by(left_count, |item1, item2| {
-                f64::partial_cmp(&item1.point[coord], &item2.point[coord]).unwrap()
-            });
-        let left_len = left.len();
-        items.split_at_mut(left_len)
-    };
-
-    let left_weight: W = left.iter().map(|item| item.weight).sum();
-
-    SplitResult {
-        left,
-        right,
-        left_weight,
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-enum Direction {
-    Left,
-    Right,
-}
-
-#[derive(Debug)]
-struct SyncItemResult<W> {
-    goto: Direction,
-    left_weight: W,
-    right_weight: W,
-}
-
-#[tracing::instrument(skip(ctx), ret)]
-async fn sync_item_split<'d, 'p, W>(
-    ctx: &IterationState<W>,
-    mut data: MutexGuard<'d, IterationData<W>>,
-    min: f64,
-    max: f64,
-    thread_left_count: usize,
-    thread_left_weight: W,
-) -> (MutexGuard<'d, IterationData<W>>, Option<SyncItemResult<W>>)
-where
-    W: RcbWeight,
-{
-    if max != data.max || min != data.min {
-        // This thread is lagging behind: discard work, advance to the
-        // correct split target and restart.
-        return (data, None);
-    }
-
-    data.ttl = data.ttl.checked_sub(1).unwrap();
-    data.left_part_count += thread_left_count;
-    data.left_part_weight += thread_left_weight;
-
-    let mut left_weight = data.additional_left_weight + data.left_part_weight;
-    let mut remaining_weight = data.sum - left_weight;
-
-    let goto = if remaining_weight < left_weight {
-        // Weight of the items on the left is already dominating, no
-        // need to compute any further.
-        Direction::Left
-    } else if data.ttl == 0 {
-        // This thread is the last one to update the state, prepare for
-        // the next iteration.
-        Direction::Right
-    } else {
-        while max == data.max && min == data.min && data.ttl != 0 {
-            data = ctx.c.wait(data).await;
-        }
-        if data.ttl == 0 {
-            // Some threads have left and the next split_target has not
-            // been chosen. Since no thread has hit the branch where
-            // the remaining_weight is lower that left_weight, it means
-            // left_weight < right_weight.
-            // Don't forget to also update left_weight and remaining_weight!
-            left_weight = data.additional_left_weight + data.left_part_weight;
-            remaining_weight = data.sum - left_weight;
-            Direction::Right
-        } else {
-            // All other threads have finished the iteration and the
-            // next one has started, prepare for it.
-            return (data, None);
-        }
-    };
-
-    let res = SyncItemResult {
-        goto,
-        left_weight,
-        right_weight: remaining_weight,
-    };
-    (data, Some(res))
-}
-
-/// # Panics
-///
-/// This function panics if `items` is empty.
-#[tracing::instrument(skip(ctx, items), ret)]
-async fn item_split_idx<'p, const D: usize, W>(
-    ctx: &IterationState<W>,
-    items: &mut [Item<'p, D, W>],
-    coord: usize,
-    tolerance: f64,
-) -> usize
-where
-    W: RcbWeight,
-{
-    let (mut min, mut max) = compute_min_max(ctx, items, coord).await;
-
-    let min_search_space = (max - min) * tolerance;
-    let mut item_view = &mut *items;
-    let mut median_idx = 0;
-    let mut cached_thread_left_count = 0;
-    let mut cached_thread_left_weight = W::default();
-
-    while ctx.run.load(Ordering::Relaxed) {
-        let split_target = (min + max) / 2.0;
-        let split = try_split_items(item_view, coord, split_target);
-        let thread_left_count = split.left.len() + cached_thread_left_count;
-        let thread_left_weight = split.left_weight + cached_thread_left_weight;
-
-        let data = ctx.data.lock().await;
-        let (mut data, update_global_state) =
-            sync_item_split(ctx, data, min, max, thread_left_count, thread_left_weight).await;
-
-        let goto = match &update_global_state {
-            Some(SyncItemResult { goto, .. }) => *goto,
-            None => {
-                min = data.min;
-                max = data.max;
-                if split_target <= data.min {
-                    Direction::Right
-                } else {
-                    Direction::Left
-                }
-            }
-        };
-
-        match goto {
-            Direction::Left => {
-                median_idx = split.left.len();
-                item_view = split.left;
-            }
-            Direction::Right => {
-                median_idx = 0;
-                item_view = split.right;
-                cached_thread_left_count = thread_left_count;
-                cached_thread_left_weight = thread_left_weight;
-            }
-        }
-        if item_view.is_empty() {
-            ctx.thread_count.fetch_sub(1, Ordering::Relaxed);
-        }
-
-        match update_global_state {
-            Some(sync) => {
-                match goto {
-                    Direction::Left => {
-                        max = split_target;
-                        data.max = split_target;
-                        if data.ttl == 0 {
-                            // Only update number of weights below data.max if all
-                            // threads have contributed to data.left_part_count.
-                            data.count_left_max = data.left_part_count;
-                        }
-                    }
-                    Direction::Right => {
-                        min = split_target;
-                        data.min = split_target;
-                        data.count_left_min = data.left_part_count;
-                        data.additional_left_weight = sync.left_weight;
-                    }
-                }
-                let respect_tolerance = {
-                    let imbalance = (sync.left_weight - sync.right_weight)
-                        .to_f64()
-                        .unwrap()
-                        .abs();
-                    let max_imbalance = tolerance * data.sum.to_f64().unwrap();
-                    imbalance < max_imbalance
-                };
-                let small_search_space = max - min < min_search_space;
-                let empty_search_space = data.count_left_min == data.count_left_max;
-                if respect_tolerance || small_search_space || empty_search_space {
-                    tracing::info!(
-                        respect_tolerance,
-                        small_search_space,
-                        empty_search_space,
-                        "stopped iteration",
-                    );
-                    ctx.run.store(false, Ordering::Relaxed);
-                }
-
-                data.left_part_count = 0;
-                data.left_part_weight = W::default();
-                data.ttl = ctx.thread_count.load(Ordering::Relaxed);
-                ctx.c.notify_all();
-                if item_view.is_empty() {
-                    break;
-                }
-            }
-            None => {
-                if item_view.is_empty() {
-                    data.ttl = data.ttl.checked_sub(1).unwrap();
-                    ctx.c.notify_all();
-                    break;
-                }
-            }
-        }
-    }
-
-    median_idx + cached_thread_left_count
-}
-
-fn rcb_iter<'p, const D: usize, W>(
-    iter_ctxs: &'p [IterationState<W>],
-    items: &'p mut [Item<'p, D, W>],
-    iter_count: usize,
-    iter_id: usize,
-    coord: usize,
-    tolerance: f64,
-) -> Pin<Box<dyn Future<Output = ()> + 'p>>
-where
-    W: RcbWeight,
-{
-    use tracing::Instrument as _;
-
-    let fut = async move {
-        if iter_count == 0 {
-            // No need to split, all thoses items are in the same part.
-            apply_part_id(items, iter_id);
-            return;
-        }
-        if items.is_empty() {
-            // No items left in this thread, remove it from global state.
-            cancel_iterations(iter_ctxs, iter_count, iter_id).await;
-            return;
-        }
-
-        let ctx = &iter_ctxs[iter_id];
-        let split_idx = item_split_idx(ctx, &mut *items, coord, tolerance).await;
-        let (left, right) = items.split_at_mut(split_idx);
-
-        tracing::info!("cut result: left={}, right={}", left.len(), right.len());
-
-        let left_task = rcb_iter(
-            iter_ctxs,
-            left,
-            iter_count - 1,
-            iter_id * 2 + 1,
-            (coord + 1) % D,
-            tolerance,
-        );
-        let right_task = rcb_iter(
-            iter_ctxs,
-            right,
-            iter_count - 1,
-            iter_id * 2 + 2,
-            (coord + 1) % D,
-            tolerance,
-        );
-        futures_lite::future::zip(left_task, right_task).await;
-    };
-
-    let span = tracing::info_span!("rcb_iter", iter_count, iter_id);
-    Box::pin(fut.instrument(span))
-}
-
-fn rcb_thread<const D: usize, W>(
-    iter_ctxs: &[IterationState<W>],
-    items: &[Item<'_, D, W>],
-    iter_count: usize,
-    tolerance: f64,
-) where
-    W: RcbWeight,
-{
-    let copy_span = tracing::info_span!("copy items");
-    let enter = copy_span.enter();
-
-    let mut items = items.to_vec();
-
-    mem::drop(enter);
-
-    let task = rcb_iter(iter_ctxs, &mut items, iter_count, 0, 0, tolerance);
-    futures_lite::future::block_on(task);
-}
-
-fn rcb<const D: usize, P, W>(
-    partition: &mut [usize],
-    points: P,
-    weights: W,
-    iter_count: usize,
-    tolerance: f64,
-) -> Result<(), Error>
-where
-    P: rayon::iter::IntoParallelIterator<Item = PointND<D>>,
-    P::Iter: rayon::iter::IndexedParallelIterator,
-    W: rayon::iter::IntoParallelIterator,
-    W::Item: RcbWeight,
-    W::Iter: rayon::iter::IndexedParallelIterator,
-{
-    let points = points.into_par_iter();
-    let weights = weights.into_par_iter();
-
-    if weights.len() != partition.len() {
-        return Err(Error::InputLenMismatch {
-            expected: partition.len(),
-            actual: weights.len(),
-        });
-    }
-    if points.len() != partition.len() {
-        return Err(Error::InputLenMismatch {
-            expected: partition.len(),
-            actual: points.len(),
-        });
-    }
-    if partition.is_empty() {
-        // Would make the partition.min() at the end panic.
-        return Ok(());
-    }
-
-    let init_span = tracing::info_span!("convert input and make initial data structures");
-    let enter = init_span.enter();
-
-    let mut items: Vec<_> = points
-        .zip(weights)
-        .zip(unsafe { mem::transmute::<&mut [usize], &[AtomicUsize]>(&mut *partition) })
-        .map(|((point, weight), part)| Item {
-            point,
-            weight,
-            part,
-        })
-        .collect();
-    let (items_per_thread, thread_count) =
-        crate::work_share(items.len(), rayon::current_num_threads());
-    let iteration_ctxs: Vec<_> = (0..usize::pow(2, iter_count as u32 + 1) - 1)
-        .map(|_| IterationState::new(thread_count))
-        .collect();
-
-    mem::drop(enter);
-
-    rayon::in_place_scope(|s| {
-        for chunk in items.chunks_mut(items_per_thread) {
-            let iteration_ctxs = &iteration_ctxs;
-            s.spawn(move |_| rcb_thread(iteration_ctxs, chunk, iter_count, tolerance));
-        }
-    });
-
-    let part_id_offset = *partition.par_iter().min().unwrap();
-    partition
-        .par_iter_mut()
-        .for_each(|part_id| *part_id -= part_id_offset);
-
-    Ok(())
-}
-
-fn simple_rcb_recurse<const D: usize, W>(
+fn rcb_recurse<const D: usize, W>(
     items: Vec<&mut [Item<D, W>]>,
     total_weight: W,
     iter_count: usize,
@@ -647,7 +92,7 @@ fn simple_rcb_recurse<const D: usize, W>(
 
     rayon::join(
         || {
-            simple_rcb_recurse(
+            rcb_recurse(
                 lefts,
                 global_left_weight,
                 iter_count - 1,
@@ -657,7 +102,7 @@ fn simple_rcb_recurse<const D: usize, W>(
             )
         },
         || {
-            simple_rcb_recurse(
+            rcb_recurse(
                 rights,
                 total_weight - global_left_weight,
                 iter_count - 1,
@@ -669,7 +114,7 @@ fn simple_rcb_recurse<const D: usize, W>(
     );
 }
 
-fn simple_rcb<const D: usize, P, W>(
+fn rcb<const D: usize, P, W>(
     partition: &mut [usize],
     points: P,
     weights: W,
@@ -728,7 +173,7 @@ where
 
     mem::drop(enter);
 
-    simple_rcb_recurse(items, total_weight, iter_count, 0, 0, tolerance);
+    rcb_recurse(items, total_weight, iter_count, 0, 0, tolerance);
 
     let part_id_offset = *partition.par_iter().min().unwrap();
     partition
@@ -817,9 +262,6 @@ pub struct Rcb {
     ///
     /// Negative values are interpreted as zeroes.
     pub tolerance: f64,
-
-    /// Use a faster, experimental implementation of the algorithm.
-    pub fast: bool,
 }
 
 impl<const D: usize, P, W> crate::Partition<(P, W)> for Rcb
@@ -842,11 +284,7 @@ where
             // Would make Itertools::minmax().into_option() return None.
             return Ok(());
         }
-        if self.fast {
-            rcb(part_ids, points, weights, self.iter_count, self.tolerance)
-        } else {
-            simple_rcb(part_ids, points, weights, self.iter_count, self.tolerance)
-        }
+        rcb(part_ids, points, weights, self.iter_count, self.tolerance)
     }
 }
 
@@ -883,7 +321,7 @@ where
     let mbr = Mbr::from_points(points);
     let points = points.par_iter().map(|p| mbr.mbr_to_aabb(p));
     // When the rotation is done, we just apply RCB
-    simple_rcb(partition, points, weights, n_iter, tolerance)
+    rcb(partition, points, weights, n_iter, tolerance)
 }
 
 /// # Recursive Inertial Bisection algorithm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ pub use crate::geometry::Aabb;
 pub use crate::geometry::{Point2D, Point3D, PointND};
 use crate::nextafter::nextafter;
 pub use crate::real::Real;
-use crate::work_share::work_share;
 use std::cmp::Ordering;
 
 /// The `Partition` trait allows for partitioning data.


### PR DESCRIPTION
Results:

The idea is to split the input sets into 2*thread_count chunks and,
sort then split each one of them.

Thus every iteration we deal with 2*thread_count chunks instead of one
big array, where sort would not play nice.

below are strong scaling graphs for 1 and 10 iterations of RCB (2 and 1024 parts):

- the `2sepsplit` variant (sequential time: 4.2s for 1iter/38s for 10iters) is the one of this PR. the points are split in `2*thread_count` chunks, in separate allocations (each one is a `Vec`),
- the `2split` variant is similar except the chunks are part of the same allocation (they are mut slices of the same `Vec`),
- the `base` variant has twice less chunks (one per thread) and they are part of the same allocation
- the `old` variant (sequential time: 1.3s/8.3s) is the `simple_rcb` from the master branch

![base strong](https://user-images.githubusercontent.com/51088794/169505441-3c2dfe1e-801f-4fc6-82c5-323ef74ab95b.svg)
