### PR TITLE
geometry: rename Aabb and Mbr

### DIFF
--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -10,7 +10,8 @@
 //!
 //! The complexity of encoding a point is O(order)
 
-use crate::geometry::{Mbr, Point2D};
+use crate::geometry::OrientedBoundingBox;
+use crate::Point2D;
 use rayon::prelude::*;
 use std::fmt;
 
@@ -97,14 +98,12 @@ fn segment_to_segment(min: f64, max: f64, order: usize) -> impl Fn(f64) -> u64 {
 }
 
 fn hilbert_index_computer(points: &[Point2D], order: usize) -> impl Fn(&Point2D) -> u64 {
-    let mbr = Mbr::from_points(points);
+    let mbr = OrientedBoundingBox::from_points(points);
     let aabb = mbr.aabb();
-    let p_min = aabb.p_min();
-    let p_max = aabb.p_max();
-    let x_mapping = segment_to_segment(p_min.x, p_max.x, order);
-    let y_mapping = segment_to_segment(p_min.y, p_max.y, order);
+    let x_mapping = segment_to_segment(aabb.p_min.x, aabb.p_max.x, order);
+    let y_mapping = segment_to_segment(aabb.p_min.y, aabb.p_max.y, order);
     move |p| {
-        let p = mbr.mbr_to_aabb(p);
+        let p = mbr.obb_to_aabb(p);
         encode(x_mapping(p.x), y_mapping(p.y), order)
     }
 }

--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -22,6 +22,9 @@ fn hilbert_curve_partition(
     part_count: usize,
     order: usize,
 ) {
+    debug_assert!(!partition.is_empty()); // to compute the bounding box
+    debug_assert_eq!(partition.len(), points.len());
+    debug_assert_eq!(partition.len(), weights.len());
     debug_assert!(order < 64);
 
     let compute_hilbert_index = hilbert_index_computer(points, order);
@@ -97,8 +100,9 @@ fn segment_to_segment(min: f64, max: f64, order: usize) -> impl Fn(f64) -> u64 {
     }
 }
 
+/// Panics if `points` is empty.
 fn hilbert_index_computer(points: &[Point2D], order: usize) -> impl Fn(&Point2D) -> u64 {
-    let mbr = OrientedBoundingBox::from_points(points);
+    let mbr = OrientedBoundingBox::from_points(points).unwrap();
     let aabb = mbr.aabb();
     let x_mapping = segment_to_segment(aabb.p_min.x, aabb.p_max.x, order);
     let y_mapping = segment_to_segment(aabb.p_min.y, aabb.p_max.y, order);
@@ -325,6 +329,9 @@ where
                 max: 63,
                 actual: self.order,
             });
+        }
+        if part_ids.is_empty() {
+            return Ok(());
         }
         hilbert_curve_partition(
             part_ids,

--- a/src/algorithms/k_means.rs
+++ b/src/algorithms/k_means.rs
@@ -286,12 +286,16 @@ fn balanced_k_means_iter<const D: usize>(
     }
 }
 
-// This is the main load balance routine. It handles:
-//   - reordering the clusters according to their distance to a bounding box of all the points
-//   - assigning each point to the closest cluster according to the effective distance
-//   - checking partitions imbalance
-//   - increasing of diminishing clusters influence based on their imbalance
-//   - relaxing upper and lower bounds
+/// This is the main load balance routine. It handles:
+///   - reordering the clusters according to their distance to a bounding box of all the points
+///   - assigning each point to the closest cluster according to the effective distance
+///   - checking partitions imbalance
+///   - increasing of diminishing clusters influence based on their imbalance
+///   - relaxing upper and lower bounds
+///
+/// # Panics
+///
+/// Panics if `points` is empty.
 fn assign_and_balance<const D: usize>(
     points: &[PointND<D>],
     weights: &[f64],
@@ -316,11 +320,11 @@ fn assign_and_balance<const D: usize>(
     } = clusters;
     // compute the distances from each cluster center to the minimal
     // bounding rectangle of the set of points
-    let mbr = OrientedBoundingBox::from_points(points);
+    let obb = OrientedBoundingBox::from_points(points).unwrap();
     let distances_to_mbr = centers
         .par_iter()
         .zip(influences.par_iter())
-        .map(|(center, influence)| mbr.distance_to_point(center) * influence)
+        .map(|(center, influence)| obb.distance_to_point(center) * influence)
         .collect::<Vec<_>>();
 
     let mut zipped = centers

--- a/src/algorithms/k_means.rs
+++ b/src/algorithms/k_means.rs
@@ -2,8 +2,9 @@
 //! "Balanced k-means for Parallel Geometric Partitioning" by Moritz von Looz,
 //! Charilaos Tzovas and Henning Meyerhenke (2018, University of Cologne)
 
-use crate::geometry::Mbr;
-use crate::geometry::{self, PointND};
+use crate::geometry;
+use crate::geometry::OrientedBoundingBox;
+use crate::PointND;
 use nalgebra::allocator::Allocator;
 use nalgebra::ArrayStorage;
 use nalgebra::Const;
@@ -315,7 +316,7 @@ fn assign_and_balance<const D: usize>(
     } = clusters;
     // compute the distances from each cluster center to the minimal
     // bounding rectangle of the set of points
-    let mbr = Mbr::from_points(points);
+    let mbr = OrientedBoundingBox::from_points(points);
     let distances_to_mbr = centers
         .par_iter()
         .zip(influences.par_iter())

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -1,5 +1,5 @@
 use super::Error;
-use crate::geometry::Mbr;
+use crate::geometry::OrientedBoundingBox;
 use crate::geometry::PointND;
 use async_lock::Mutex;
 use async_lock::MutexGuard;
@@ -892,8 +892,8 @@ where
     W::Item: RcbWeight,
     W::Iter: rayon::iter::IndexedParallelIterator,
 {
-    let mbr = Mbr::from_points(points);
-    let points = points.par_iter().map(|p| mbr.mbr_to_aabb(p));
+    let mbr = OrientedBoundingBox::from_points(points);
+    let points = points.par_iter().map(|p| mbr.obb_to_aabb(p));
     // When the rotation is done, we just apply RCB
     simple_rcb(partition, points, weights, n_iter, tolerance)
 }

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -892,8 +892,11 @@ where
     W::Item: RcbWeight,
     W::Iter: rayon::iter::IndexedParallelIterator,
 {
-    let mbr = OrientedBoundingBox::from_points(points);
-    let points = points.par_iter().map(|p| mbr.obb_to_aabb(p));
+    let obb = match OrientedBoundingBox::from_points(points) {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let points = points.par_iter().map(|p| obb.obb_to_aabb(p));
     // When the rotation is done, we just apply RCB
     simple_rcb(partition, points, weights, n_iter, tolerance)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod topology;
 mod work_share;
 
 pub use crate::algorithms::*;
-pub use crate::geometry::Aabb;
+pub use crate::geometry::BoundingBox;
 pub use crate::geometry::{Point2D, Point3D, PointND};
 use crate::nextafter::nextafter;
 pub use crate::real::Real;

--- a/tools/src/bin/medit2svg.rs
+++ b/tools/src/bin/medit2svg.rs
@@ -229,9 +229,11 @@ where
             mesh.node_count(),
         )
     };
-    let aabb = coupe::Aabb::<2>::from_points(coordinates.par_iter().cloned());
-    let [xmin, ymin] = <[f64; 2]>::from(*aabb.p_min());
-    let [xmax, ymax] = <[f64; 2]>::from(*aabb.p_max());
+    let bb = coupe::BoundingBox::<2>::from_points(coordinates.par_iter().cloned());
+    let xmin = bb.p_min[0];
+    let xmax = bb.p_max[0];
+    let ymin = bb.p_min[1];
+    let ymax = bb.p_max[1];
     let width = xmax - xmin;
     let height = ymax - ymin;
     writeln!(

--- a/tools/src/bin/medit2svg.rs
+++ b/tools/src/bin/medit2svg.rs
@@ -229,7 +229,10 @@ where
             mesh.node_count(),
         )
     };
-    let bb = coupe::BoundingBox::<2>::from_points(coordinates.par_iter().cloned());
+    let bb = match coupe::BoundingBox::<2>::from_points(coordinates.par_iter().cloned()) {
+        Some(v) => v,
+        None => return Ok(()),
+    };
     let xmin = bb.p_min[0];
     let xmax = bb.p_max[0];
     let ymin = bb.p_min[1];


### PR DESCRIPTION
Extracted from #153

Renamed `Aabb` (axis aligned bounding box) to just `BoundinxBox`

Also renamed `Mbr` to `OrientedBoundingBox` (instead of arbitrarily oriented bounding box). Let me know if you have a better name for this.

Aabb is used for rcb in #165 to keep track of the min/max of each coordinate