### PR TITLE
rcb: prerequisites for GPU acceleration

### DIFF
--- a/ffi/src/data.rs
+++ b/ffi/src/data.rs
@@ -47,7 +47,7 @@ impl Constant {
 
     pub unsafe fn par_iter<'a, T>(
         &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send + Sync,
     {
@@ -85,7 +85,7 @@ impl Array {
 
     pub unsafe fn par_iter<'a, T>(
         &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send + Sync,
     {
@@ -132,7 +132,7 @@ impl Fn {
 
     pub unsafe fn par_iter<'a, T>(
         &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + 'a
+    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send,
     {


### PR DESCRIPTION
This PR changes the "array of structs" data structure in RCB to a "struct of arrays" (one for the weights, one for part IDs, and one for each dimension) to provide efficient data transfers to the GPU (and also allow for SIMD processing)

TODO
- [x] update commented-out unit tests 