### PR TITLE
tools: add a weak-scaling measurement tool

### DIFF
--- a/tools/report/efficiency-weak
+++ b/tools/report/efficiency-weak
@@ -1,0 +1,114 @@
+#!/bin/sh
+set -e
+
+. "$(dirname "$0")"/common.sh
+
+command -v gnuplot >/dev/null || {
+	echo "command 'gnuplot' not found" >&2
+	exit 1
+}
+
+[ $# -lt 2 ] && {
+	echo "usage: $0 BASELINE BENCHMARK_GROUPS..." >&2
+	exit 1
+}
+
+BASELINE=$1
+shift
+
+TARGET_DIR=$(cargo metadata --format-version=1 | jq -r '.target_directory')
+csv="$BASELINE.weak.csv"
+svg="$BASELINE.weak.svg"
+
+bg_path() {
+	benchmark_group=$1
+
+	benchmark_dir=$(echo "$benchmark_group" | tr ':' '_' | cut -b-64)
+	echo "$TARGET_DIR/criterion/$benchmark_dir"
+}
+
+time_ns() {
+	benchmark_group=$1
+	threads=$2
+
+	path="$(bg_path "$benchmark_group")/refine=$threads/$BASELINE/estimates.json"
+	if [ -f "$path" ]
+	then jq -r '.mean.point_estimate' <"$path"
+	else return 1
+	fi
+}
+
+stddev_ns() {
+	threads=$1
+
+	path="$(bg_path "$benchmark_group")/refine=$threads/$BASELINE/estimates.json"
+	if [ -f "$path" ]
+	then jq -r '.mean.standard_error' <"$path"
+	else return 1
+	fi
+}
+
+sayfile Aggregating "$csv"
+
+thread_counts=$(
+for benchmark_group in "$@"
+do
+	for bench in "$(bg_path "$benchmark_group")/refine="*
+	do
+		thread_count=$(echo "$bench" | sed 's/.*refine=\(.*\)/\1/')
+		echo "$thread_count"
+	done
+done | sort -n | uniq
+)
+
+(
+	printf "thread count"
+	for benchmark_group in "$@"
+	do
+		group=$(echo "$benchmark_group" | tr ';' '_')
+		printf " ; %s" "$group"
+	done
+	printf "\n"
+) >"$csv"
+
+echo "$thread_counts" | while read -r thread_count
+do
+	printf "%d" "$thread_count"
+	for benchmark_group in "$@"
+	do
+		if t=$(time_ns "$benchmark_group" "$thread_count")
+		then
+			t_seq=$(time_ns "$benchmark_group" 1)
+			speedup=$(echo "$thread_count * $t_seq / $t" | bc -l)
+			printf " ; %f" "$speedup"
+		else
+			printf " ;"
+		fi
+	done
+	printf "\n"
+done >>"$csv"
+
+max_thread_count=$(echo "$thread_counts" | tail -n1)
+plot_cmds=$(awk -v csv="$csv" "BEGIN{
+	for (i=1; i<ARGC; i++) {
+		gsub(/_/, \"\\\\_\", ARGV[i])
+		printf \",'%s' using 1:%d title '%s' with linespoints\",csv,i+1,ARGV[i]
+	}
+}" $@)
+
+gnuplot <<EOF
+	set output '$svg'
+	set datafile separator ';'
+	set term svg size 1366,768
+
+	set title 'Weak scaling'
+	set xlabel 'Number of threads'
+	set ylabel 'Speedup'
+	set xrange [1:$max_thread_count]
+	set logscale x 2
+	set logscale y 2
+	set grid ytics
+	plot x title 'Ideal' dashtype 2 $plot_cmds
+EOF
+
+say Rendered "$svg"

--- a/tools/report/weak-scaling
+++ b/tools/report/weak-scaling
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# Usage example:
+#
+#     ./tools/report/weak-scaling monkey.meshb spike,1000 -a random,2 -a fm,0.04
+
+set -e
+
+. "$(dirname "$0")"/common.sh
+cargo build -p coupe-tools --bins --release
+PATH="$TARGET_DIR/release:$PATH"
+TARGET_DIR=./target
+
+MESH_FILE=$1
+shift
+
+WEIGHT_DIST=$1
+shift
+
+tmp_mesh=$(echo 'maketemp(/dev/shm/weak-scaling.XXXXXX)' | m4)
+tmp_weights="$tmp_mesh".weights
+trap "rm -f $tmp_mesh $tmp_weights" 0 2 3 15
+
+bench_name=$(basename "$tmp_mesh" | tr '.' ';')
+for arg in $@
+do
+	if [ "$arg" != "${arg#-}" ]
+	then continue
+	fi
+	bench_name="$bench_name;$arg"
+done
+
+max_threads=$(grep -c ^processor /proc/cpuinfo)
+RAYON_NUM_THREADS=1
+
+mesh_dup() {
+	n=$1
+
+	say dedup "$MESH_FILE"
+	rm "$tmp_mesh"
+	mesh-dup -n "$n" <"$MESH_FILE" >"$tmp_mesh"
+}
+
+weight_gen() {
+	say weight-gen "$tmp_weights"
+	weight-gen --distribution "$WEIGHT_DIST" <"$tmp_mesh" >"$tmp_weights"
+}
+
+part_bench() {
+	say bench "$RAYON_NUM_THREADS threads"
+	part-bench --mesh "$tmp_mesh" \
+	           --weights "$tmp_weights" \
+	           --sample-size 10 \
+	           --edge-weights linear \
+	           $@
+
+	cd "$TARGET_DIR/criterion/$bench_name"
+
+	dir="refine=$RAYON_NUM_THREADS"
+	mkdir "$dir"
+	mv base new "$dir"
+	cp -r report "$dir"
+
+	cd - >/dev/null
+}
+
+ln -sf "$(realpath "$MESH_FILE")" "$tmp_mesh"
+weight_gen
+
+while true
+do
+	part_bench $@
+
+	RAYON_NUM_THREADS=$(( $RAYON_NUM_THREADS * 2 ))
+	if [ $RAYON_NUM_THREADS -gt $max_threads ]
+	then
+		break
+	fi
+
+	mesh_dup "$RAYON_NUM_THREADS"
+	weight_gen
+
+	say sleep "Cooling CPUs down for 4s..."
+	sleep 4
+done


### PR DESCRIPTION
a little POSIX shell script that measures the weak scaling of an
algorithm with the help of part-bench, weight-gen and mesh-refine.

Example:

    ./tools/report/weak-scaling monkey.meshb spike,1000 -a random,2 -a fm,0.04

#### vs building this feature directly inside part-bench

The shell script was easier to code, but the overhead might be worth removing: the mesh is read twice per iteration (once by weight-gen and once by part-bench) and it uses the filesystem to store intermediate results.