### PR TITLE
Enable the rust_2018_idioms lint as warning

### DIFF
--- a/src/algorithms/fiduccia_mattheyses.rs
+++ b/src/algorithms/fiduccia_mattheyses.rs
@@ -34,7 +34,7 @@ struct Move {
 fn fiduccia_mattheyses<W>(
     partition: &mut [usize],
     weights: &[W],
-    adjacency: CsMatView<i64>,
+    adjacency: CsMatView<'_, i64>,
     max_passes: usize,
     max_moves_per_pass: usize,
     max_imbalance: Option<f64>,
@@ -362,7 +362,7 @@ where
     fn partition(
         &mut self,
         part_ids: &mut [usize],
-        (adjacency, weights): (CsMatView<i64>, &'a [W]),
+        (adjacency, weights): (CsMatView<'_, i64>, &'a [W]),
     ) -> Result<Self::Metadata, Self::Error> {
         if part_ids.is_empty() {
             return Ok(Metadata::default());

--- a/src/algorithms/graph_growth.rs
+++ b/src/algorithms/graph_growth.rs
@@ -4,7 +4,7 @@ use sprs::CsMatView;
 fn graph_growth(
     initial_ids: &mut [usize],
     weights: &[f64],
-    adjacency: CsMatView<f64>,
+    adjacency: CsMatView<'_, f64>,
     num_parts: usize,
 ) {
     let (shape_x, shape_y) = adjacency.shape();
@@ -126,7 +126,7 @@ where
     fn partition(
         &mut self,
         part_ids: &mut [usize],
-        (adjacency, weights): (CsMatView<f64>, W),
+        (adjacency, weights): (CsMatView<'_, f64>, W),
     ) -> Result<Self::Metadata, Self::Error> {
         graph_growth(
             part_ids,

--- a/src/algorithms/k_means.rs
+++ b/src/algorithms/k_means.rs
@@ -174,10 +174,10 @@ struct AlgorithmState<'a> {
 //  - checking delta threshold
 //  - relaxing lower and upper bounds
 fn balanced_k_means_iter<const D: usize>(
-    inputs: Inputs<D>,
+    inputs: Inputs<'_, D>,
     clusters: Clusters<Vec<PointND<D>>, &[ClusterId]>,
     permutation: &mut [usize],
-    state: AlgorithmState,
+    state: AlgorithmState<'_>,
     settings: &BalancedKmeansSettings,
     current_iter: usize,
 ) where
@@ -300,7 +300,7 @@ fn assign_and_balance<const D: usize>(
     points: &[PointND<D>],
     weights: &[f64],
     permutation: &mut [usize],
-    state: AlgorithmState,
+    state: AlgorithmState<'_>,
     clusters: Clusters<&[PointND<D>], &[ClusterId]>,
     settings: &BalancedKmeansSettings,
 ) where

--- a/src/algorithms/kernighan_lin.rs
+++ b/src/algorithms/kernighan_lin.rs
@@ -9,7 +9,7 @@ use sprs::CsMatView;
 fn kernighan_lin(
     part_ids: &mut [usize],
     weights: &[f64],
-    adjacency: CsMatView<f64>,
+    adjacency: CsMatView<'_, f64>,
     max_passes: Option<usize>,
     max_flips_per_pass: Option<usize>,
     max_imbalance_per_flip: Option<f64>,
@@ -34,7 +34,7 @@ fn kernighan_lin(
 fn kernighan_lin_2_impl(
     initial_partition: &mut [usize],
     weights: &[f64],
-    adjacency: CsMatView<f64>,
+    adjacency: CsMatView<'_, f64>,
     max_passes: Option<usize>,
     max_flips_per_pass: Option<usize>,
     _max_imbalance_per_flip: Option<f64>,
@@ -265,7 +265,7 @@ impl<'a> crate::Partition<(CsMatView<'a, f64>, &'a [f64])> for KernighanLin {
     fn partition(
         &mut self,
         part_ids: &mut [usize],
-        (adjacency, weights): (CsMatView<f64>, &'a [f64]),
+        (adjacency, weights): (CsMatView<'_, f64>, &'a [f64]),
     ) -> Result<Self::Metadata, Self::Error> {
         kernighan_lin(
             part_ids,

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -151,7 +151,7 @@ where
 }
 
 fn rcb_recurse<const D: usize, W>(
-    items: &mut [Item<D, W>],
+    items: &mut [Item<'_, D, W>],
     iter_count: usize,
     iter_id: usize,
     coord: usize,
@@ -576,7 +576,7 @@ mod tests {
             let sum: u32 = weights.iter().sum();
 
             let part = &AtomicUsize::new(0);
-            let mut items: Vec<Item<2, u32>> = points
+            let mut items: Vec<Item<'_, 2, u32>> = points
                 .into_iter()
                 .zip(weights)
                 .map(|(point, weight)| Item {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 //! - [Fiduccia-Mattheyses][FiducciaMattheyses]
 //! - [Kernighan-Lin][KernighanLin]
 
+#![warn(rust_2018_idioms)]
+
 mod algorithms;
 mod geometry;
 pub mod imbalance;

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -27,7 +27,7 @@ use std::iter::Sum;
 ///    1*  ┆╲ ╱            
 ///          * 0
 /// ```
-pub fn edge_cut<T>(adjacency: CsMatView<T>, partition: &[usize]) -> T
+pub fn edge_cut<T>(adjacency: CsMatView<'_, T>, partition: &[usize]) -> T
 where
     T: Copy + Sum + Send + Sync + PartialEq,
 {
@@ -53,7 +53,7 @@ where
         .sum()
 }
 
-pub fn lambda_cut<T>(adjacency: CsMatView<T>, partition: &[usize]) -> usize {
+pub fn lambda_cut<T>(adjacency: CsMatView<'_, T>, partition: &[usize]) -> usize {
     let indptr = adjacency.indptr().into_raw_storage();
     let indices = adjacency.indices();
     indptr
@@ -92,7 +92,7 @@ pub fn lambda_cut<T>(adjacency: CsMatView<T>, partition: &[usize]) -> usize {
 ///
 /// If the entry `(i, j)` is non-zero, then its value is the weight of the edge between `i`
 /// and `j` (default to `1.0`).
-pub fn adjacency_matrix(conn: CsMatView<u32>, num_common_nodes: u32) -> CsMat<f64> {
+pub fn adjacency_matrix(conn: CsMatView<'_, u32>, num_common_nodes: u32) -> CsMat<f64> {
     // currently this matmul operation is very slow
     let graph = &conn * &conn.transpose_view();
 


### PR DESCRIPTION
This should become the default in the future:
https://github.com/rust-lang/rust/issues/54910

Reason this is put in lib.rs instead of CI: to ensure local invocations
of cargo build and cargo clippy pick up the warning.

Reason this is made a warning: so that code builds and runs anyway. On
the CI, the `-D warnings` clippy argument will treat it as a hard error.