### PR TITLE
rcb: SIMD partitioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,13 @@ readme = "README.md"
 repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 autobenches = false
 
+[features]
+default = []
+
+# Enable the nightly `stdsimd` feature and AVX512-accelerated algorithms.
+# Requires rust nightly.
+avx512 = []
+
 [dependencies]
 approx = "0.5"
 itertools = "0.10"

--- a/src/algorithms/k_means.rs
+++ b/src/algorithms/k_means.rs
@@ -244,8 +244,8 @@ fn balanced_k_means_iter<const D: usize>(
             .iter()
             .zip(points.iter().cloned())
             .into_group_map()
-            .into_iter()
-            .map(|(_assignment, points)| max_distance(&points))
+            .into_values()
+            .map(|points| max_distance(&points))
             .sum::<f64>()
             / centers.len() as f64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! - [Fiduccia-Mattheyses][FiducciaMattheyses]
 //! - [Kernighan-Lin][KernighanLin]
 
+#![cfg_attr(feature = "avx512", feature(stdsimd))]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -814,6 +814,7 @@ pub fn write_mesh(
     Ok(())
 }
 
+#[cfg(any(feature = "metis", feature = "scotch"))]
 fn zoom_in<I, O, W>(inputs: I) -> Vec<O>
 where
     I: IntoIterator,


### PR DESCRIPTION
This commit adds a SIMD variant for the partitioning step (splitting the array of coordinates into two).

Bramas, B. (2017) ‘A Novel Hybrid Quicksort Algorithm Vectorized using
AVX-512 on Intel Skylake’, International Journal of Advanced Computer
Science and Applications, 8(10). <doi:10.14569/IJACSA.2017.081044>.

^ the partitioning algorithm in this paper is the one used in google's highway project:
https://github.com/google/highway/blob/c25f7f568ddd61e51c3e93c74377558176e5d108/hwy/contrib/sort/vqsort-inl.h#L280

AVX512F, AVX512VL and rust nightly[^1] are required, check support on your machine with

    rustc +nightly --print cfg -C target-cpu=native | grep -E 'avx512f|avx512vl'

This implementation uses `__m256` registers instead of `__m512` since coordinates are `f32` and part IDs (of type `&AtomicUsize`) can be double the size.

## TODO

- [x] put the split function behind a feature flag, so that coupe can still compile on rust stable
- [x] partition other coord arrays too
- [x] partition weight array
- [x] partition part ref array
- [ ] ... or use a permutation array instead of partitioning everything?

[^1]: AVX512 target features are currently unstable and locked behind the `stdsimd` feature gate