### PR TITLE
tools: don't build all crates for quality reports

### DIFF
--- a/tools/report/common.sh
+++ b/tools/report/common.sh
@@ -59,4 +59,3 @@ command -v jq >/dev/null || {
 }
 
 TARGET_DIR=$(cargo metadata --format-version=1 | jq -r '.target_directory')
-PATH="$TARGET_DIR/release:$PATH"

--- a/tools/report/quality
+++ b/tools/report/quality
@@ -2,7 +2,8 @@
 set -e
 
 . "$(dirname "$0")"/common.sh
-cargo build --all --bins --release
+cargo build -p coupe-tools --bins --release
+PATH="$TARGET_DIR/release:$PATH"
 
 OUTPUT_DIR="$TARGET_DIR/coupe-report"
 say mkdir "$OUTPUT_DIR"


### PR DESCRIPTION
Only coupe-tools binary are used actually.  This reduces the number of
dependencies to build.