### PR TITLE
tools: add a mesh duplication tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,9 @@ dependencies = [
 [[package]]
 name = "mesh-io"
 version = "0.1.0"
+dependencies = [
+ "itertools",
+]
 
 [[package]]
 name = "mesh-io-ffi"

--- a/tools/doc/mesh-dup.1.scd
+++ b/tools/doc/mesh-dup.1.scd
@@ -2,21 +2,16 @@ mesh-refine(1)
 
 # NAME
 
-mesh-refine - Refine a mesh
+mesh-dup - Duplicate the elements of a mesh
 
 # SYNOPSIS
 
-*mesh-refine* [--times <n>] <input.mesh >output.mesh
+*mesh-dup* [--times <n>] <input.mesh >output.mesh
 
 # DESCRIPTION
 
-mesh-refine splits the cell of a mesh from its standard input into smaller
-cells and prints the resulting mesh on its standard output, mainly for
-performance tests on algorithms.
-
-mesh-refine only works on 2D meshes composed exclusively of triangles and
-quadrilaterals.  It splits either of them into four equal parts at each
-iteration.
+mesh-dup copies the elements of a mesh a number of times so that the output mesh
+forms a (hyper)grid of input meshs, mainly for performance tests on algorithms.
 
 Only MEDIT meshes are supported, for now.  See *apply-part(1)*'s *INPUT FORMAT*
 for details.
@@ -35,7 +30,7 @@ for details.
 
 # SEE ALSO
 
-*mesh-dup*(1) *mesh-part*(1)
+*mesh-refine*(1) *mesh-part*(1)
 
 # AUTHORS
 

--- a/tools/mesh-io/Cargo.toml
+++ b/tools/mesh-io/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
 
 
 [dependencies]
+itertools = "0.10"

--- a/tools/src/bin/mesh-dup.rs
+++ b/tools/src/bin/mesh-dup.rs
@@ -1,0 +1,42 @@
+use anyhow::Context as _;
+use anyhow::Result;
+use mesh_io::medit::Mesh;
+use std::env;
+use std::io;
+
+const USAGE: &str = "Usage: mesh-dup [options] <in.mesh >out.mesh";
+
+fn main() -> Result<()> {
+    let mut options = getopts::Options::new();
+    options.optflag("h", "help", "print this help menu");
+    options.optopt("f", "format", "output format", "EXT");
+    options.optopt("n", "times", "numbers of duplicates (default: 2)", "NUMBER");
+
+    let matches = options.parse(env::args().skip(1))?;
+
+    if matches.opt_present("h") {
+        eprintln!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if !matches.free.is_empty() {
+        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
+    }
+
+    let format: coupe_tools::MeshFormat = matches
+        .opt_get("f")
+        .context("invalid value for option 'format'")?
+        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+
+    let n: usize = matches
+        .opt_get("n")
+        .context("invalid value for option 'times'")?
+        .unwrap_or(2);
+
+    let stdin = io::stdin();
+    let stdin = stdin.lock();
+    let stdin = io::BufReader::new(stdin);
+    let mesh = Mesh::from_reader(stdin).context("failed to read mesh")?;
+    coupe_tools::write_mesh(&mesh.duplicate(n), format)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Used to duplicate a mesh N times for finer-grained weak scaling
measurements.

In a future commit, it should be possible to connect the duplicates
together by mirroring half of them.