### PR TITLE
ci: lint for cargo metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,5 +92,6 @@ jobs:
           args: >
             --all --all-targets --
             -D warnings
+            -D clippy::cargo_common_metadata
             -D clippy::negative_feature_names
             -D clippy::redundant_feature_names

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -2,6 +2,12 @@
 name = "coupe-ffi"
 version = "0.1.0"
 edition = "2021"
+description = "C bindings to coupe"
+license = "MIT OR Apache-2.0"
+keywords = ["mesh", "partitioning"]
+categories = ["algorithms", "mathematics"]
+readme = "README.md"
+repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [lib]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -3,6 +3,12 @@ name = "coupe-tools"
 version = "0.1.0"
 edition = "2021"
 authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
+description = "Tools to work with coupe from the command line"
+license = "MIT OR Apache-2.0"
+keywords = ["cli", "mesh", "partitioning"]
+categories = ["algorithms", "command-line-utilities", "mathematics"]
+readme = "README.md"
+repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [features]

--- a/tools/mesh-io/Cargo.toml
+++ b/tools/mesh-io/Cargo.toml
@@ -3,6 +3,12 @@ name = "mesh-io"
 version = "0.1.0"
 edition = "2021"
 authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
+description = "(de)serializing library for various mesh formats"
+license = "MIT OR Apache-2.0"
+keywords = ["mesh", "parser"]
+categories = ["mathematics", "parsing"]
+readme = "../README.md"
+repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [dependencies]

--- a/tools/mesh-io/ffi/Cargo.toml
+++ b/tools/mesh-io/ffi/Cargo.toml
@@ -3,6 +3,12 @@ name = "mesh-io-ffi"
 version = "0.1.0"
 edition = "2021"
 authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
+description = "C bindings to mesh-io"
+license = "MIT OR Apache-2.0"
+keywords = ["mesh", "parser"]
+categories = ["mathematics", "parsing"]
+readme = "../../README.md"
+repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [lib]

--- a/tools/num-part/Cargo.toml
+++ b/tools/num-part/Cargo.toml
@@ -3,6 +3,12 @@ name = "num-part"
 version = "0.1.0"
 edition = "2021"
 authors = ["Hubert Hirtz <hubert@hirtz.pm>"]
+description = "Command-line framework to measure quality of number-partitioning algorithms"
+license = "MIT OR Apache-2.0"
+keywords = ["cli", "partitioning"]
+categories = ["algorithms", "command-line-utilities", "mathematics"]
+readme = "../README.md"
+repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [dependencies]


### PR DESCRIPTION
related to C-METADATA from the Rust API guidelines
<https://rust-lang.github.io/api-guidelines/checklist.html>

See #176