### PR TITLE
ci: lint for missing debug implementations

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -84,6 +84,7 @@ impl std::error::Error for Error {}
 ///     .partition(&mut partition, ())
 ///     .unwrap();
 /// ```
+#[derive(Debug)]
 pub struct Random<R> {
     pub rng: R,
     pub part_count: usize,

--- a/src/algorithms/ckk.rs
+++ b/src/algorithms/ckk.rs
@@ -148,6 +148,7 @@ where
 /// Korf, Richard E., 1998. A complete anytime algorithm for number
 /// partitioning. *Artificial Intelligence*, 106(2):181 – 203.
 /// <doi:10.1016/S0004-3702(98)00086-1>.
+#[derive(Debug)]
 pub struct CompleteKarmarkarKarp {
     /// Constraint on the normalized imbalance between the two parts.
     pub tolerance: f64,

--- a/src/algorithms/greedy.rs
+++ b/src/algorithms/greedy.rs
@@ -79,6 +79,7 @@ impl<T> GreedyWeight for T where Self: PartialOrd + num::Zero + Clone + AddAssig
 /// Horowitz, Ellis and Sahni, Sartaj, 1974. Computing partitions with
 /// applications to the knapsack problem. *J. ACM*, 21(2):277–292.
 /// <doi:10.1145/321812.321823>.
+#[derive(Debug)]
 pub struct Greedy {
     pub part_count: usize,
 }

--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -296,6 +296,7 @@ impl std::error::Error for Error {}
 ///
 /// Marot, Célestin. *Parallel tetrahedral mesh generation*. Prom.: Remacle,
 /// Jean-François <http://hdl.handle.net/2078.1/240626>.
+#[derive(Debug)]
 pub struct HilbertCurve {
     pub part_count: usize,
     pub order: u32,

--- a/src/algorithms/kk.rs
+++ b/src/algorithms/kk.rs
@@ -149,6 +149,7 @@ impl<T> KkWeight for T where Self: num::Zero + Ord + Sub<Output = Self> + SubAss
 ///
 /// Karmarkar, Narenda and Karp, Richard M., 1983. The differencing method of
 /// set partitioning. Technical report, Berkeley, CA, USA.
+#[derive(Debug)]
 pub struct KarmarkarKarp {
     pub part_count: usize,
 }

--- a/src/algorithms/multi_jagged.rs
+++ b/src/algorithms/multi_jagged.rs
@@ -362,6 +362,7 @@ pub(crate) fn split_at_mut_many<'a, T>(
 ///     }
 /// }
 /// ```
+#[derive(Debug)]
 pub struct MultiJagged {
     pub part_count: usize,
     pub max_iter: usize,

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -506,7 +506,7 @@ where
 /// Berger, M. J. and Bokhari, S. H., 1987. A partitioning strategy for
 /// nonuniform problems on multiprocessors. *IEEE Transactions on Computers*,
 /// C-36(5):570–580. <doi:10.1109/TC.1987.1676942>.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Rcb {
     /// The number of iterations of the algorithm. This will yield a partition
     /// of at most `2^num_iter` parts.
@@ -626,7 +626,7 @@ where
 /// Williams, Roy D., 1991. Performance of dynamic load balancing algorithms for
 /// unstructured mesh calculations. *Concurrency: Practice and Experience*,
 /// 3(5):457–481. <doi:10.1002/cpe.4330030502>.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Rib {
     /// The number of iterations of the algorithm. This will yield a partition
     /// of at most `2^num_iter` parts.

--- a/src/algorithms/vn/best.rs
+++ b/src/algorithms/vn/best.rs
@@ -176,6 +176,7 @@ where
 /// Remi Barat. Load Balancing of Multi-physics Simulation by Multi-criteria
 /// Graph Partitioning. Other [cs.OH]. Université de Bordeaux, 2017. English.
 /// NNT : 2017BORD0961. tel-01713977
+#[derive(Debug)]
 pub struct VnBest {
     pub part_count: usize,
 }

--- a/src/algorithms/vn/first.rs
+++ b/src/algorithms/vn/first.rs
@@ -242,6 +242,7 @@ where
 /// Remi Barat. Load Balancing of Multi-physics Simulation by Multi-criteria
 /// Graph Partitioning. Other [cs.OH]. Université de Bordeaux, 2017. English.
 /// NNT : 2017BORD0961. tel-01713977
+#[derive(Debug)]
 pub struct VnFirst {
     pub part_count: usize,
 }

--- a/src/algorithms/z_curve.rs
+++ b/src/algorithms/z_curve.rs
@@ -171,6 +171,7 @@ fn z_curve_partition_recurse<const D: usize>(
 /// assert_eq!(partition[4], partition[5]);
 /// assert_eq!(partition[6], partition[7]);
 /// ```  
+#[derive(Debug)]
 pub struct ZCurve {
     pub part_count: usize,
     pub order: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! - [Fiduccia-Mattheyses][FiducciaMattheyses]
 //! - [Kernighan-Lin][KernighanLin]
 
-#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations, rust_2018_idioms)]
 
 mod algorithms;
 mod geometry;

--- a/tools/mesh-io/src/lib.rs
+++ b/tools/mesh-io/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_debug_implementations, rust_2018_idioms)]
+
 pub mod medit;
 pub mod partition;
 pub mod weight;

--- a/tools/mesh-io/src/medit/parser.rs
+++ b/tools/mesh-io/src/medit/parser.rs
@@ -25,7 +25,7 @@ pub struct Error {
 }
 
 impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::UnexpectedToken { expected, found } => {
                 write!(f, "expected token {:?}, found {}", expected, found)
@@ -38,7 +38,7 @@ impl fmt::Display for ErrorKind {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "at line {}: {}", self.lineno, self.kind)
     }
 }

--- a/tools/mesh-io/src/weight.rs
+++ b/tools/mesh-io/src/weight.rs
@@ -11,6 +11,7 @@ use std::io;
 const VERSION: u8 = 1;
 const FLAG_INTEGER: u8 = 1 << 0;
 
+#[derive(Debug)]
 pub enum Array {
     Integers(Vec<Vec<i64>>),
     Floats(Vec<Vec<f64>>),


### PR DESCRIPTION
related to C-METADATA from the Rust API guidelines
<https://rust-lang.github.io/api-guidelines/checklist.html>

This lint is specifically added to the rust libraries: coupe and
mesh-io.

See #176