### PR TITLE
ci: lint for missing Copy implementations

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -38,7 +38,7 @@ pub use vn::VnFirstWeight;
 pub use z_curve::ZCurve;
 
 /// Common errors thrown by algorithms.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// No partition that matches the given criteria could been found.

--- a/src/algorithms/ckk.rs
+++ b/src/algorithms/ckk.rs
@@ -148,7 +148,7 @@ where
 /// Korf, Richard E., 1998. A complete anytime algorithm for number
 /// partitioning. *Artificial Intelligence*, 106(2):181 – 203.
 /// <doi:10.1016/S0004-3702(98)00086-1>.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct CompleteKarmarkarKarp {
     /// Constraint on the normalized imbalance between the two parts.
     pub tolerance: f64,

--- a/src/algorithms/greedy.rs
+++ b/src/algorithms/greedy.rs
@@ -79,7 +79,7 @@ impl<T> GreedyWeight for T where Self: PartialOrd + num::Zero + Clone + AddAssig
 /// Horowitz, Ellis and Sahni, Sartaj, 1974. Computing partitions with
 /// applications to the knapsack problem. *J. ACM*, 21(2):277–292.
 /// <doi:10.1145/321812.321823>.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Greedy {
     pub part_count: usize,
 }

--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -227,7 +227,7 @@ fn encode(x: u64, y: u64, order: usize) -> u64 {
     hilbert >> -shift
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Invalid space filling curve order.
@@ -296,7 +296,7 @@ impl std::error::Error for Error {}
 ///
 /// Marot, Célestin. *Parallel tetrahedral mesh generation*. Prom.: Remacle,
 /// Jean-François <http://hdl.handle.net/2078.1/240626>.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct HilbertCurve {
     pub part_count: usize,
     pub order: u32,

--- a/src/algorithms/kk.rs
+++ b/src/algorithms/kk.rs
@@ -149,7 +149,7 @@ impl<T> KkWeight for T where Self: num::Zero + Ord + Sub<Output = Self> + SubAss
 ///
 /// Karmarkar, Narenda and Karp, Richard M., 1983. The differencing method of
 /// set partitioning. Technical report, Berkeley, CA, USA.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct KarmarkarKarp {
     pub part_count: usize,
 }

--- a/src/algorithms/multi_jagged.rs
+++ b/src/algorithms/multi_jagged.rs
@@ -362,7 +362,7 @@ pub(crate) fn split_at_mut_many<'a, T>(
 ///     }
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MultiJagged {
     pub part_count: usize,
     pub max_iter: usize,

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -506,7 +506,7 @@ where
 /// Berger, M. J. and Bokhari, S. H., 1987. A partitioning strategy for
 /// nonuniform problems on multiprocessors. *IEEE Transactions on Computers*,
 /// C-36(5):570–580. <doi:10.1109/TC.1987.1676942>.
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Rcb {
     /// The number of iterations of the algorithm. This will yield a partition
     /// of at most `2^num_iter` parts.
@@ -626,7 +626,7 @@ where
 /// Williams, Roy D., 1991. Performance of dynamic load balancing algorithms for
 /// unstructured mesh calculations. *Concurrency: Practice and Experience*,
 /// 3(5):457–481. <doi:10.1002/cpe.4330030502>.
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Rib {
     /// The number of iterations of the algorithm. This will yield a partition
     /// of at most `2^num_iter` parts.

--- a/src/algorithms/vn/best.rs
+++ b/src/algorithms/vn/best.rs
@@ -176,7 +176,7 @@ where
 /// Remi Barat. Load Balancing of Multi-physics Simulation by Multi-criteria
 /// Graph Partitioning. Other [cs.OH]. Université de Bordeaux, 2017. English.
 /// NNT : 2017BORD0961. tel-01713977
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct VnBest {
     pub part_count: usize,
 }

--- a/src/algorithms/vn/first.rs
+++ b/src/algorithms/vn/first.rs
@@ -242,7 +242,7 @@ where
 /// Remi Barat. Load Balancing of Multi-physics Simulation by Multi-criteria
 /// Graph Partitioning. Other [cs.OH]. Université de Bordeaux, 2017. English.
 /// NNT : 2017BORD0961. tel-01713977
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct VnFirst {
     pub part_count: usize,
 }

--- a/src/algorithms/z_curve.rs
+++ b/src/algorithms/z_curve.rs
@@ -171,7 +171,7 @@ fn z_curve_partition_recurse<const D: usize>(
 /// assert_eq!(partition[4], partition[5]);
 /// assert_eq!(partition[6], partition[7]);
 /// ```  
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ZCurve {
     pub part_count: usize,
     pub order: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@
 //! - [Fiduccia-Mattheyses][FiducciaMattheyses]
 //! - [Kernighan-Lin][KernighanLin]
 
-#![warn(missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    rust_2018_idioms
+)]
 
 mod algorithms;
 mod geometry;

--- a/tools/mesh-io/src/lib.rs
+++ b/tools/mesh-io/src/lib.rs
@@ -1,4 +1,8 @@
-#![warn(missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    rust_2018_idioms
+)]
 
 pub mod medit;
 pub mod partition;


### PR DESCRIPTION
related to C-COMMON-TRAITS from the Rust API guidelines
<https://rust-lang.github.io/api-guidelines/checklist.html>

This lint is specifically added to the rust libraries: coupe and
mesh-io.

See #176