### PR TITLE
tools: only compute dual and barycentres when needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "mesh-io",
  "metis",
  "num",
+ "once_cell",
  "rand",
  "rand_pcg",
  "rayon",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -44,6 +44,7 @@ criterion = { version = "0.3", default-features = false }
 # Other utilities
 itertools = { version = "0.10", default-features = false }
 num = { version = "0.4", default-features = false }
+once_cell = "1.10"
 rayon = "1.3"
 affinity = { version = "0.1", default-features = false }
 sprs = { version = "0.11", default-features = false, features = ["multi_thread"] }

--- a/tools/src/bin/part-bench/main.rs
+++ b/tools/src/bin/part-bench/main.rs
@@ -75,28 +75,13 @@ fn main_d<const D: usize>(
     let mut algorithms: Vec<_> = algorithm_specs
         .iter()
         .map(|algorithm_spec| {
-            coupe_tools::parse_algorithm(algorithm_spec)
+            coupe_tools::parse_algorithm::<D>(algorithm_spec)
                 .with_context(|| format!("invalid algorithm {:?}", algorithm_spec))
         })
         .collect::<Result<_>>()?;
 
-    let (adjacency, points) = rayon::join(
-        || {
-            let mut adjacency = coupe_tools::dual(&mesh);
-            if edge_weights != coupe_tools::EdgeWeightDistribution::Uniform {
-                coupe_tools::set_edge_weights(&mut adjacency, &weights, edge_weights);
-            }
-            adjacency
-        },
-        || coupe_tools::barycentres::<D>(&mesh),
-    );
-
-    let problem = coupe_tools::Problem {
-        points,
-        weights,
-        adjacency,
-    };
-    let mut partition = vec![0; problem.points.len()];
+    let mut partition = vec![0; coupe_tools::used_element_count(&mesh)];
+    let problem = coupe_tools::Problem::new(mesh, weights, edge_weights);
 
     let mut runners: Vec<_> = algorithms
         .iter_mut()

--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -20,7 +20,7 @@ impl<const D: usize> ToRunner<D> for Recursive {
         let ncon = weights.first().map_or(1, Vec::len) as Idx;
         let mut weights: Vec<_> = weights.iter().flatten().map(|i| *i as Idx).collect();
 
-        let (xadj, adjncy, _) = problem.adjacency.view().into_raw_storage();
+        let (xadj, adjncy, _) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
 
@@ -52,7 +52,7 @@ impl<const D: usize> ToRunner<D> for KWay {
         let ncon = weights.first().map_or(1, Vec::len) as Idx;
         let mut weights: Vec<_> = weights.iter().flatten().map(|i| *i as Idx).collect();
 
-        let (xadj, adjncy, _) = problem.adjacency.view().into_raw_storage();
+        let (xadj, adjncy, _) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
 

--- a/tools/src/scotch.rs
+++ b/tools/src/scotch.rs
@@ -22,7 +22,7 @@ impl<const D: usize> ToRunner<D> for Standard {
         }
         let weights: Vec<_> = weights.iter().map(|i| i[0] as Num).collect();
 
-        let (xadj, adjncy, _) = problem.adjacency.view().into_raw_storage();
+        let (xadj, adjncy, _) = problem.adjacency().into_raw_storage();
         let xadj: Vec<_> = xadj.iter().map(|i| *i as Num).collect();
         let adjncy: Vec<_> = adjncy.iter().map(|i| *i as Num).collect();
 


### PR DESCRIPTION
Computing the dual takes some time and is not needed when all algorithms
are geometric.  This commit makes it so the dual (and barycentres, for
topologic/number runs) is only computed when necessary.

Somewhat related to #126