### PR TITLE
Reexport dependencies of coupe's public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,10 +197,6 @@ name = "coupe-ffi"
 version = "0.1.0"
 dependencies = [
  "coupe",
- "nalgebra",
- "num",
- "rayon",
- "sprs",
 ]
 
 [[package]]
@@ -216,13 +212,11 @@ dependencies = [
  "ittapi",
  "mesh-io",
  "metis",
- "num",
  "once_cell",
  "rand",
  "rand_pcg",
  "rayon",
  "scotch",
- "sprs",
  "tracing-chrome",
  "tracing-subscriber",
  "tracing-tree",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -21,7 +21,3 @@ crate-type = [
 
 [dependencies]
 coupe = { version = "0.1", path = ".." }
-nalgebra = { version = "0.29", default-features = false, features = ["std"] }
-num = "0.4"
-rayon = "1.3"
-sprs = { version = "0.11", default-features = false }

--- a/ffi/src/data.rs
+++ b/ffi/src/data.rs
@@ -1,7 +1,8 @@
-use rayon::iter::IntoParallelIterator as _;
-use rayon::iter::IntoParallelRefIterator as _;
-use rayon::iter::ParallelExtend as _;
-use rayon::iter::ParallelIterator as _;
+use coupe::rayon::iter::IndexedParallelIterator;
+use coupe::rayon::iter::IntoParallelIterator as _;
+use coupe::rayon::iter::IntoParallelRefIterator as _;
+use coupe::rayon::iter::ParallelExtend as _;
+use coupe::rayon::iter::ParallelIterator as _;
 use std::borrow::Cow;
 use std::collections::TryReserveError;
 use std::ffi::c_void;
@@ -45,14 +46,12 @@ impl Constant {
         (0..self.len).map(move |_| value)
     }
 
-    pub unsafe fn par_iter<'a, T>(
-        &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
+    pub unsafe fn par_iter<'a, T>(&'a self) -> impl IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send + Sync,
     {
         let value = *(self.value as *const T);
-        rayon::iter::repeatn(value, self.len)
+        coupe::rayon::iter::repeatn(value, self.len)
     }
 }
 
@@ -83,9 +82,7 @@ impl Array {
             .cloned()
     }
 
-    pub unsafe fn par_iter<'a, T>(
-        &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
+    pub unsafe fn par_iter<'a, T>(&'a self) -> impl IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send + Sync,
     {
@@ -130,9 +127,7 @@ impl Fn {
         })
     }
 
-    pub unsafe fn par_iter<'a, T>(
-        &'a self,
-    ) -> impl rayon::iter::IndexedParallelIterator<Item = T> + Clone + 'a
+    pub unsafe fn par_iter<'a, T>(&'a self) -> impl IndexedParallelIterator<Item = T> + Clone + 'a
     where
         T: 'a + Copy + Send,
     {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2,17 +2,19 @@
 
 use crate::data::Data;
 use crate::data::Type;
+use coupe::nalgebra::allocator::Allocator;
+use coupe::nalgebra::ArrayStorage;
+use coupe::nalgebra::Const;
+use coupe::nalgebra::DefaultAllocator;
+use coupe::nalgebra::DimDiff;
+use coupe::nalgebra::DimSub;
+use coupe::nalgebra::ToTypenum;
+use coupe::sprs::CsMatView;
+use coupe::sprs::CSR;
 use coupe::Partition as _;
 use coupe::Point2D;
 use coupe::PointND;
 use coupe::Real;
-use nalgebra::allocator::Allocator;
-use nalgebra::ArrayStorage;
-use nalgebra::Const;
-use nalgebra::DefaultAllocator;
-use nalgebra::DimDiff;
-use nalgebra::DimSub;
-use nalgebra::ToTypenum;
 use std::ffi::c_void;
 use std::mem;
 use std::os::raw::c_char;
@@ -154,9 +156,9 @@ pub extern "C" fn coupe_data_fn(
 }
 
 pub enum Adjncy<'a> {
-    Int(sprs::CsMatView<'a, c_int>),
-    Int64(sprs::CsMatView<'a, i64>),
-    Double(sprs::CsMatView<'a, f64>),
+    Int(CsMatView<'a, c_int>),
+    Int64(CsMatView<'a, i64>),
+    Double(CsMatView<'a, f64>),
 }
 
 #[no_mangle]
@@ -179,20 +181,17 @@ unsafe fn adjncy_csr_unchecked(
     match data_type {
         Type::Int => {
             let data = slice::from_raw_parts(data as *const c_int, adjncy.len());
-            let matrix =
-                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            let matrix = CsMatView::new_unchecked(CSR, (size, size), xadj, adjncy, data);
             Adjncy::Int(matrix)
         }
         Type::Int64 => {
             let data = slice::from_raw_parts(data as *const i64, adjncy.len());
-            let matrix =
-                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            let matrix = CsMatView::new_unchecked(CSR, (size, size), xadj, adjncy, data);
             Adjncy::Int64(matrix)
         }
         Type::Double => {
             let data = slice::from_raw_parts(data as *const f64, adjncy.len());
-            let matrix =
-                sprs::CsMatView::new_unchecked(sprs::CSR, (size, size), xadj, adjncy, data);
+            let matrix = CsMatView::new_unchecked(CSR, (size, size), xadj, adjncy, data);
             Adjncy::Double(matrix)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub use crate::geometry::BoundingBox;
 pub use crate::geometry::{Point2D, Point3D, PointND};
 use crate::nextafter::nextafter;
 pub use crate::real::Real;
+
+pub use nalgebra;
+pub use num::traits as num_traits;
+pub use rayon;
+pub use sprs;
+
 use std::cmp::Ordering;
 
 /// The `Partition` trait allows for partitioning data.

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -49,8 +49,6 @@ criterion = { version = "0.3", default-features = false }
 
 # Other utilities
 itertools = { version = "0.10", default-features = false }
-num = { version = "0.4", default-features = false }
 once_cell = "1.10"
 rayon = "1.3"
 affinity = { version = "0.1", default-features = false }
-sprs = { version = "0.11", default-features = false, features = ["multi_thread"] }

--- a/tools/src/bin/medit2svg.rs
+++ b/tools/src/bin/medit2svg.rs
@@ -1,5 +1,6 @@
 use anyhow::Context as _;
 use anyhow::Result;
+use coupe::sprs::CsMatView;
 use coupe::Point2D;
 use mesh_io::medit::ElementType;
 use mesh_io::medit::Mesh;
@@ -60,7 +61,7 @@ fn add_element_and_neighbors_to_path<'a>(
     path_ref: isize,
     el: usize,
     element_fn: impl Fn(usize) -> (ElementType, &'a [usize], isize) + Copy,
-    adjacency: sprs::CsMatView<f64>,
+    adjacency: CsMatView<f64>,
 ) {
     let mut queue = Vec::new();
     queue.push(el);
@@ -130,7 +131,7 @@ fn frontier<'a>(
     el_set: &HashSet<usize>,
     mesh: &Mesh,
     element_fn: impl Fn(usize) -> (ElementType, &'a [usize], isize),
-    adjacency: sprs::CsMatView<f64>,
+    adjacency: CsMatView<f64>,
 ) -> Vec<Vec<Point2D>> {
     let path_set = el_set
         .iter()

--- a/tools/src/bin/mesh-part.rs
+++ b/tools/src/bin/mesh-part.rs
@@ -153,9 +153,12 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use coupe::sprs::CsMat;
+    use coupe::sprs::CSR;
+
     #[test]
     fn test_adjacency_convert() {
-        let mut adjacency = sprs::CsMat::empty(sprs::CSR, 15);
+        let mut adjacency = CsMat::empty(CSR, 15);
         adjacency.reserve_outer_dim(15);
         adjacency.insert(0, 1, 1.0);
         adjacency.insert(0, 5, 1.0);

--- a/tools/src/bin/part-info.rs
+++ b/tools/src/bin/part-info.rs
@@ -1,5 +1,8 @@
 use anyhow::Context as _;
 use anyhow::Result;
+use coupe::num_traits::FromPrimitive;
+use coupe::num_traits::ToPrimitive;
+use coupe::num_traits::Zero;
 use mesh_io::medit::Mesh;
 use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::IntoParallelRefIterator as _;
@@ -13,7 +16,7 @@ const USAGE: &str = "Usage: part-info [options]";
 fn imbalance<T>(part_count: usize, part_ids: &[usize], weights: &[Vec<T>]) -> Vec<f64>
 where
     T: Copy + Send + Sync,
-    T: num::FromPrimitive + num::ToPrimitive + num::Zero,
+    T: FromPrimitive + ToPrimitive + Zero,
     T: std::ops::Div<Output = T> + std::ops::Sub<Output = T> + std::iter::Sum,
 {
     let criterion_count = match weights.first() {


### PR DESCRIPTION
Namely nalgebra, num traits, rayon and sprs.

Those crates appear in coupe's public API (through function parameters
and trait bounds). Having reexports allows consumers of the library to
use it without adding extra dependencies in their package manifest. 