### PR TITLE
ffi: derive Eq

### DIFF
--- a/ffi/src/data.rs
+++ b/ffi/src/data.rs
@@ -8,7 +8,7 @@ use std::collections::TryReserveError;
 use std::ffi::c_void;
 use std::slice;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub enum Type {
     Int,


### PR DESCRIPTION
Fix clippy lint introduced in clippy 1.63.