### PR TITLE
arcswap: kway generalization

### DIFF
--- a/src/algorithms/arc_swap.rs
+++ b/src/algorithms/arc_swap.rs
@@ -86,9 +86,9 @@ where
             }
             None => {
                 let max_part_weight = *part_weights.iter().max_by(partial_cmp).unwrap();
-                max_part_weight
-                    + (max_part_weight + max_part_weight - total_weight)
-                        / W::from_usize(2 * thread_count).unwrap()
+                let ideal_part_weight = total_weight / W::from_usize(part_count).unwrap();
+                ideal_part_weight
+                    + (max_part_weight - ideal_part_weight) / W::from_usize(thread_count).unwrap()
             }
         };
         (total_weight, part_weights[0], max_part_weight)

--- a/src/algorithms/arc_swap.rs
+++ b/src/algorithms/arc_swap.rs
@@ -1,26 +1,15 @@
 use super::Error;
 use crate::defer::defer;
+use crate::partial_cmp;
 use crate::work_share::work_share;
 use rayon::iter::IndexedParallelIterator as _;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
 use sprs::CsMatView;
-use std::cmp;
 use std::mem;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-
-fn partial_cmp<W>(a: &W, b: &W) -> cmp::Ordering
-where
-    W: PartialOrd,
-{
-    if a < b {
-        cmp::Ordering::Less
-    } else {
-        cmp::Ordering::Greater
-    }
-}
 
 /// Diagnostic data for a [ArcSwap] run.
 #[non_exhaustive]

--- a/tools/report/common.sh
+++ b/tools/report/common.sh
@@ -6,21 +6,30 @@ ALGORITHMS="
 -a rcb,1
 -a rcb,1 -a arcswap,0.05
 -a rcb,1 -a fm,0.05
+-a rcb,1 -a fm,0.05,16
 -a hilbert,2
 -a hilbert,2 -a arcswap,0.05
 -a hilbert,2 -a fm,0.05
+-a hilbert,2 -a fm,0.05,16
 
 -a kk,3
--a kk,3 -a fm,0.05
+-a kk,3 -a arcswap,0.05
 -a hilbert,3
+-a hilbert,3 -a arcswap,0.05
 
 -a kk,4
+-a kk,4 -a arcswap,0.05
 -a rcb,2
+-a rcb,2 -a arcswap,0.05
 -a hilbert,4
+-a hilbert,4 -a arcswap,0.05
 
 -a kk,128
+-a kk,128 -a arcswap,0.05
 -a rcb,7
+-a rcb,7 -a arcswap,0.05
 -a hilbert,128
+-a hilbert,128 -a arcswap,0.05
 "
 
 WEIGHT_DISTRIBUTIONS="


### PR DESCRIPTION
This just makes arcswap consider all parts when making a move.

For each vertex to move, arcswap considers all the parts to move it to,
then picks the part that yields the greatest gain.

### TODO

- [x] double-check the way thread-local imbalance thresholds are computed
- [x] Correctly update `part0_weight`
- [ ] Investigate cases where imbalance thresholds are exceeded