### PR TITLE
part-info: add the -E,--edge-weights option 

### DIFF
--- a/tools/doc/part-info.1.scd
+++ b/tools/doc/part-info.1.scd
@@ -24,6 +24,10 @@ for details.
 *-h, --help*
 	Show a help message and exit.
 
+*-E, --edge-weights* <variant>
+	Change how edge weights are set.  Possible values are listed in
+	*mesh-part*(1).
+
 *-m, --mesh* <path>
 	Required.  A path to the mesh that has been partitionned.
 

--- a/tools/report/quality
+++ b/tools/report/quality
@@ -168,7 +168,7 @@ do
 				Algorithm: <code>$algorithm</code>
 				<pre>
 				$(cat "${svg_file%.*}.log")
-				$(part-info --mesh "$mesh_file" --weights "$weight_file" --partition "${svg_file%.*}.part")
+				$(part-info --mesh "$mesh_file" --weights "$weight_file" --partition "${svg_file%.*}.part" --edge-weights linear)
 				mesh file: ${svg_file%.*}.mesh
 				</pre>
 				<img src="$(basename "$svg_file")" alt="$mesh_file; $weight_distribution; $algorithm">

--- a/tools/src/bin/part-info.rs
+++ b/tools/src/bin/part-info.rs
@@ -131,10 +131,18 @@ fn main() -> Result<()> {
         "edge cut: {}",
         coupe::topology::edge_cut(adjacency.view(), &parts),
     );
-    println!(
-        "lambda cut: {}",
-        coupe::topology::lambda_cut(adjacency.view(), &parts),
-    );
+    match &weights {
+        mesh_io::weight::Array::Integers(v) => {
+            let lambda_cut =
+                coupe::topology::lambda_cut(adjacency.view(), &parts, v.par_iter().map(|c| c[0]));
+            println!("lambda cut: {}", lambda_cut);
+        }
+        mesh_io::weight::Array::Floats(v) => {
+            let lambda_cut =
+                coupe::topology::lambda_cut(adjacency.view(), &parts, v.par_iter().map(|c| c[0]));
+            println!("lambda cut: {}", lambda_cut);
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
and other related changes, see individual commits for details.

It turns out reports showed incorrect edge cuts because part-info was not called with the same `--edge-weights` setting as mesh-part.

Closes #194