### PR TITLE
arcswap: fix enforcement of imbalance thresholds

### DIFF
--- a/src/algorithms/arc_swap.rs
+++ b/src/algorithms/arc_swap.rs
@@ -239,6 +239,7 @@ where
     let mut metadata =
         partition
             .par_iter()
+            .with_min_len(items_per_thread)
             .enumerate()
             .fold(
                 || (Metadata::default(), Vec::new(), part_weights.clone()),


### PR DESCRIPTION
Enforcing a minimum split length over the parallel iterator limits the
number of tasks that move vertices in parallel with the same starting
imbalance array.

Unfortunately this does not fix the issue in all cases.

Closes #197 