### PR TITLE
weight-gen: enforce linear to be within bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "mesh-io",
  "metis",
  "once_cell",
+ "proptest",
  "rand",
  "rand_pcg",
  "rayon",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod work_share;
 pub use crate::algorithms::*;
 pub use crate::geometry::BoundingBox;
 pub use crate::geometry::{Point2D, Point3D, PointND};
-use crate::nextafter::nextafter;
+pub use crate::nextafter::nextafter;
 pub use crate::real::Real;
 
 pub use nalgebra;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -52,3 +52,6 @@ itertools = { version = "0.10", default-features = false }
 once_cell = "1.10"
 rayon = "1.3"
 affinity = { version = "0.1", default-features = false }
+
+[dev-dependencies]
+proptest = { version = "1.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
Previously, linear distribution was computed as

    ALPHA = (to - from) / (max - min)
    BETA  = -min * ALPHA
    w_i = FMA(p_i, ALPHA, BETA) + from
        (ie. (p_i-min) * (to-from)/(max-min)+from)

Now it is computed as such

    ALPHA = (to - from) / (max - min)
    w_i = FMA(p_i-min, ALPHA, from)
        (ie. (p_i-min) * (to-from)/(max-min)+from)

This should do the trick:

- for the lower bound, if `p_i` is `min` then the FMA operation has 0.0 as first argument and thus should yield `from`;
- for the upper bound, this uses the same `nextafter` technique as the implementation of Hilbert curves, to work around float errors.

Closes #202