### PR TITLE
report: add a imbedgecut graph tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -24,6 +24,8 @@ includes the following tools:
     - mesh-reorder changes the order of mesh elements.
 - in the `report` directory, a collection of shell scripts that aggregate
   results into visual reports:
+    - `imbedgecut` generates an SVG graph comparing the imbalance/edge-cut of
+      various algorithms,
     - `quality` generates an HTML report of partitioning results for a given
       mesh directory,
     - `efficiency` generates a CSV file and a SVG graph showing the efficiency

--- a/tools/report/imbedgecut.sh
+++ b/tools/report/imbedgecut.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e
+
+. "$(dirname "$0")"/common.sh
+PATH="$TARGET_DIR/release:$PATH"
+
+ARGS="-m ../meshes/triangles_small.meshb -w /dev/shm/triangles.weights --edge-weights linear"
+ALGORITHMS="
+-a random,2
+-a random,2 -a arcswap,0.05
+-a random,2 -a arcswap,0.05 -a arcswap,0.05
+-a rcb,1
+-a rcb,1 -a arcswap,0.05
+-a rcb,1 -a vn-best
+-a rcb,1 -a vn-best -a arcswap,0.05
+-a hilbert,2
+-a hilbert,2 -a arcswap,0.05
+-a hilbert,2 -a vn-best
+-a hilbert,2 -a vn-best -a arcswap,0.05
+-a kk,2
+-a kk,2 -a arcswap,0.05
+-a kk,2 -a vn-best -a arcswap,0.05
+"
+
+tmpdir=$(mktemp -d /dev/shm/imbedgecut.XXXXXX)
+trap "rm -rf $tmpdir" 0 2 3 15
+
+echo "$ALGORITHMS" | while read -r algorithm
+do
+	if [ -z "$algorithm" ]
+	then continue
+	fi
+
+	iter_count=256
+	if test "${algorithm#*arcswap}" = "$algorithm"
+	then iter_count=1
+	fi
+
+	say Running "$algorithm ($iter_count times)" >&2
+
+	for _ in $(seq $iter_count)
+	do
+		info=$(
+			RAYON_NUM_THREADS=4 mesh-part $ARGS $algorithm |
+				part-info $ARGS -p /dev/stdin
+		)
+		edge_cut=$(echo "$info" | grep edge | cut -f2 -d:)
+		imbalance=$(echo "$info" | grep imbalances | sed 's/.*\[\(.*\)\]/\1/')
+		echo "$edge_cut;$imbalance"
+	done >"$tmpdir/$algorithm"
+done
+
+say Drawing histo.svg
+gnuplot <<EOF
+set term svg size 1152,648
+set output 'histo.svg'
+set datafile separator ';'
+set xlabel 'edge cut (log scale)'
+set ylabel 'imbalance'
+set title 'Imbalance/edge cut of various algorithms'
+
+set logscale x 10
+
+plot \
+$(
+	echo "$ALGORITHMS" | while read -r algorithm
+	do
+		if [ -z "$algorithm" ]
+		then continue
+		fi
+
+		file="$tmpdir/$algorithm"
+		echo "'$file' title '$algorithm', \\"
+	done
+)
+	 (0.05) with lines title 'Arcswap imbalance threshold'
+EOF


### PR DESCRIPTION
That graphs the imbalance/edge cut of algorithms, especially useful for arcswap (see #197) which is the only non-deterministic implementation currently.