### PR TITLE
tools: scale and shift vertex and edge weights for METIS and SCOTCH

### DIFF
--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -9,6 +9,9 @@ use coupe::nalgebra::DefaultAllocator;
 use coupe::nalgebra::DimDiff;
 use coupe::nalgebra::DimSub;
 use coupe::nalgebra::ToTypenum;
+use coupe::num_traits::PrimInt;
+use coupe::num_traits::ToPrimitive;
+use coupe::num_traits::Zero;
 use coupe::sprs::CsMat;
 use coupe::sprs::CsMatView;
 use coupe::sprs::CSR;
@@ -25,7 +28,9 @@ use rayon::iter::ParallelIterator as _;
 use rayon::slice::ParallelSlice as _;
 use std::any;
 use std::io;
+use std::iter::Sum;
 use std::mem;
+use std::ops::AddAssign;
 
 #[cfg(feature = "metis")]
 mod metis;
@@ -716,4 +721,41 @@ pub fn write_mesh(mesh: &Mesh, format: MeshFormat) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn zoom_in<I, O, W>(inputs: I) -> Vec<O>
+where
+    I: IntoIterator,
+    I::IntoIter: Clone + ExactSizeIterator,
+    I::Item: IntoIterator<Item = W>,
+    W: Sum + AddAssign + Clone + Zero + PartialOrd + ToPrimitive,
+    O: PrimInt,
+{
+    let inputs = inputs.into_iter();
+    let criterion_count = match inputs.clone().next() {
+        Some(v) => v.into_iter().count(),
+        None => return Vec::new(),
+    };
+    let sum = inputs
+        .clone()
+        .fold(vec![W::zero(); criterion_count], |mut acc, w| {
+            for (acc, w) in acc.iter_mut().zip(w) {
+                *acc += w;
+            }
+            acc
+        })
+        .into_iter()
+        .max_by(|a, b| W::partial_cmp(a, b).unwrap())
+        .unwrap();
+    let zoom_factor = (O::max_value() - O::from(inputs.len()).unwrap())
+        .to_f64()
+        .unwrap()
+        / sum.to_f64().unwrap();
+    let _1 = O::one();
+    inputs
+        .flat_map(move |v| {
+            v.into_iter()
+                .map(move |v| O::from(v.to_f64().unwrap() * zoom_factor).unwrap() + _1)
+        })
+        .collect()
 }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::just_underscores_and_digits)]
+
 use anyhow::Context as _;
 use anyhow::Result;
 use coupe::nalgebra::allocator::Allocator;

--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -18,12 +18,12 @@ impl<const D: usize> ToRunner<D> for Recursive {
             }
         };
         let ncon = weights.first().map_or(1, Vec::len) as Idx;
-        let mut weights: Vec<_> = weights.iter().flatten().map(|i| *i as Idx).collect();
+        let mut weights = crate::zoom_in(weights.iter().map(|v| v.iter().cloned()));
 
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = adjwgt.iter().map(|i| *i as Idx).collect();
+        let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let mut metis_partition = vec![0; weights.len()];
         Box::new(move |partition| {
@@ -52,12 +52,12 @@ impl<const D: usize> ToRunner<D> for KWay {
             }
         };
         let ncon = weights.first().map_or(1, Vec::len) as Idx;
-        let mut weights: Vec<_> = weights.iter().flatten().map(|i| *i as Idx).collect();
+        let mut weights = crate::zoom_in(weights.iter().map(|v| v.iter().cloned()));
 
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = adjwgt.iter().map(|i| *i as Idx).collect();
+        let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let mut metis_partition = vec![0; weights.len()];
         Box::new(move |partition| {

--- a/tools/src/scotch.rs
+++ b/tools/src/scotch.rs
@@ -22,12 +22,12 @@ impl<const D: usize> ToRunner<D> for Standard {
         if weights.first().map_or(1, Vec::len) != 1 {
             return runner_error("SCOTCH cannot do multi-criteria partitioning");
         }
-        let weights: Vec<_> = weights.iter().map(|i| i[0] as Num).collect();
+        let weights = crate::zoom_in(weights.iter().map(|v| v.iter().cloned()));
 
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let xadj: Vec<_> = xadj.iter().map(|i| *i as Num).collect();
         let adjncy: Vec<_> = adjncy.iter().map(|i| *i as Num).collect();
-        let adjwgt: Vec<_> = adjwgt.iter().map(|i| *i as Num).collect();
+        let adjwgt = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let mut strat = scotch::Strategy::new();
         let arch = scotch::Architecture::complete(self.part_count as Num);


### PR DESCRIPTION
These tools cannot handle null weights for vertices nor edges, so the input weights are "zoomed in" so that the sum of the weights plus one is INT_MAX.

Closes #220

### TODO

- [x] edge weights are scaled independently from vertex weights, decide whether this is good or bad and add a comment
- [x] recover multi-criteria support for metis
- [ ] ~~return an iterator instead of a Vec~~ rustc panic :s