### PR TITLE
tools: add a tolerance parameter for METIS

### DIFF
--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -438,16 +438,34 @@ where
         }),
 
         #[cfg(feature = "metis")]
-        "metis:recursive" => Box::new(metis::Recursive {
-            part_count: require(parse(args.next()))?,
-            tolerance: parse(args.next()).transpose()?,
-        }),
+        "metis:recursive" => {
+            let part_count = require(parse(args.next()))?;
+            let tolerance = parse(args.next()).transpose()?;
+            if let Some(tolerance) = tolerance {
+                if tolerance < 0.001 {
+                    anyhow::bail!("METIS does not support tolerances below 0.001");
+                }
+            }
+            Box::new(metis::Recursive {
+                part_count,
+                tolerance,
+            })
+        }
 
         #[cfg(feature = "metis")]
-        "metis:kway" => Box::new(metis::KWay {
-            part_count: require(parse(args.next()))?,
-            tolerance: parse(args.next()).transpose()?,
-        }),
+        "metis:kway" => {
+            let part_count = require(parse(args.next()))?;
+            let tolerance = parse(args.next()).transpose()?;
+            if let Some(tolerance) = tolerance {
+                if tolerance < 0.001 {
+                    anyhow::bail!("METIS does not support tolerances below 0.001");
+                }
+            }
+            Box::new(metis::KWay {
+                part_count,
+                tolerance,
+            })
+        }
 
         #[cfg(feature = "scotch")]
         "scotch:std" => Box::new(scotch::Standard {

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -440,11 +440,13 @@ where
         #[cfg(feature = "metis")]
         "metis:recursive" => Box::new(metis::Recursive {
             part_count: require(parse(args.next()))?,
+            tolerance: parse(args.next()).transpose()?,
         }),
 
         #[cfg(feature = "metis")]
         "metis:kway" => Box::new(metis::KWay {
             part_count: require(parse(args.next()))?,
+            tolerance: parse(args.next()).transpose()?,
         }),
 
         #[cfg(feature = "scotch")]

--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -2,6 +2,7 @@ use super::runner_error;
 use super::Problem;
 use super::Runner;
 use super::ToRunner;
+use anyhow::Context;
 use mesh_io::weight;
 use metis::Idx;
 
@@ -36,7 +37,9 @@ impl<const D: usize> ToRunner<D> for Recursive {
             if let Some(tolerance) = tolerance {
                 graph = graph.set_option(metis::option::UFactor(tolerance));
             }
-            graph.part_recursive(&mut metis_partition)?;
+            graph
+                .part_recursive(&mut metis_partition)
+                .context("METIS partitioning failed")?;
             for (dst, src) in partition.iter_mut().zip(&metis_partition) {
                 *dst = *src as usize;
             }
@@ -76,7 +79,9 @@ impl<const D: usize> ToRunner<D> for KWay {
             if let Some(tolerance) = tolerance {
                 graph = graph.set_option(metis::option::UFactor(tolerance));
             }
-            graph.part_kway(&mut metis_partition)?;
+            graph
+                .part_kway(&mut metis_partition)
+                .context("METIS partitioning failed")?;
             for (dst, src) in partition.iter_mut().zip(&metis_partition) {
                 *dst = *src as usize;
             }


### PR DESCRIPTION
~~not tested yet.~~

We have to multiply the tolerance by 1000 and convert it to an int for METIS.

See <https://lihpc-computational-geometry.github.io/metis-rs/metis/option/struct.UFactor.html>

By default the tolerance for Recursive is 0.001 and for Kway 0.03

Closes #226