### PR TITLE
tools: accept free arguments in addition to stdin/out

### DIFF
--- a/tools/doc/apply-part.1.scd
+++ b/tools/doc/apply-part.1.scd
@@ -8,9 +8,9 @@ apply-weight - Colorize a mesh with a weight file for visualization
 
 # SYNOPSIS
 
-*apply-part* --mesh <path> --partition <path> >output.mesh
+*apply-part* --mesh <path> --partition <path> [output.mesh]
 
-*apply-weight* --mesh <path> --weights <path> >output.mesh
+*apply-weight* --mesh <path> --weights <path> [output.mesh]
 
 # DESCRIPTION
 
@@ -18,7 +18,7 @@ apply-part (apply-weight) merges a partition file (resp. weight file) into
 the free-form fields of a MEDIT mesh file, so that the partition (resp. weight
 distribution) can be visualized with medit tools.
 
-The output mesh is written on standard output.
+If output.mesh is omitted or is -, it is written to standard output.
 
 Only MEDIT meshes are supported, for now.  See *INPUT FORMAT* for details.
 

--- a/tools/doc/mesh-dup.1.scd
+++ b/tools/doc/mesh-dup.1.scd
@@ -6,12 +6,15 @@ mesh-dup - Duplicate the elements of a mesh
 
 # SYNOPSIS
 
-*mesh-dup* [--times <n>] <input.mesh >output.mesh
+*mesh-dup* [--times <n>] [input.mesh [output.mesh]]
 
 # DESCRIPTION
 
 mesh-dup copies the elements of a mesh a number of times so that the output mesh
 forms a (hyper)grid of input meshs, mainly for performance tests on algorithms.
+
+If input.mesh is omitted or is -, it is read from standard input.
+If output.mesh is omitted or is -, it is written to standard output.
 
 Only some specific mesh formats are supported.  See *apply-part(1)*'s *INPUT
 FORMAT* for details.

--- a/tools/doc/mesh-part.1.scd
+++ b/tools/doc/mesh-part.1.scd
@@ -8,14 +8,16 @@ part-bench - Benchmark an algorithm
 
 # SYNOPSIS
 
-*mesh-part* [options...] >output.part
+*mesh-part* [options...] [output.part]
 
 *part-bench* [options...]
 
 # DESCRIPTION
 
-mesh-part applies partitioning algorithms onto a given mesh in order, and writes
-the resulting partition on standard output.
+mesh-part applies partitioning algorithms onto a given mesh in order, and
+outputs the resulting partition.
+
+If output.part is omitted or is -, it is written to standard output.
 
 part-bench benchmarks the speed of the given algorithms and prints the results.
 

--- a/tools/doc/mesh-refine.1.scd
+++ b/tools/doc/mesh-refine.1.scd
@@ -6,13 +6,15 @@ mesh-refine - Refine a mesh
 
 # SYNOPSIS
 
-*mesh-refine* [--times <n>] <input.mesh >output.mesh
+*mesh-refine* [--times <n>] [input.mesh [output.mesh]]
 
 # DESCRIPTION
 
-mesh-refine splits the cell of a mesh from its standard input into smaller
-cells and prints the resulting mesh on its standard output, mainly for
-performance tests on algorithms.
+mesh-refine splits the cell of a mesh into smaller cells, mainly for performance
+tests on algorithms.
+
+If input.mesh is omitted or is -, it is read from standard input.
+If output.mesh is omitted or is -, it is written to standard output.
 
 mesh-refine only works on 2D meshes composed exclusively of triangles and
 quadrilaterals.  It splits either of them into four equal parts at each

--- a/tools/doc/mesh-reorder.1.scd
+++ b/tools/doc/mesh-reorder.1.scd
@@ -6,13 +6,16 @@ mesh-reorder - Change the order of the vertices and the elements of a mesh
 
 # SYNOPSIS
 
-*mesh-reorder* <input.mesh >output.mesh
+*mesh-reorder* [input.mesh [output.mesh]]
 
 # DESCRIPTION
 
 mesh-reorder shuffles the vertices and the elements of a mesh, without altering
 its mathematical structure: only the order in which they appear in the file is
 changed.
+
+If input.mesh is omitted or is -, it is read from standard input.
+If output.mesh is omitted or is -, it is written to standard output.
 
 The tool can be used in conjunction of *mesh-reorder* or *mesh-dup*, which both
 produce very typical element orderings and may disrupt algorithms.

--- a/tools/doc/weight-gen.1.scd
+++ b/tools/doc/weight-gen.1.scd
@@ -6,12 +6,14 @@ weight-gen - Generate a distribution of weights for a given mesh
 
 # SYNOPSIS
 
-*weight-gen* [options...] <input.mesh >output.weights
+*weight-gen* [options...] [input.mesh [output.weights]]
 
 # DESCRIPTION
 
-weight-gen generates weights for a given mesh provided to standard input, and
-writes the output weight distribution in standard output.
+weight-gen generates weights for a given mesh.
+
+If input.mesh is omitted or is -, it is read from standard input.
+If output.weights is omitted or is -, it is written to standard output.
 
 Unless *-i, --integers* is specified, the generated weights are floating-point
 numbers.

--- a/tools/src/bin/apply-part.rs
+++ b/tools/src/bin/apply-part.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs;
 use std::io;
 
-const USAGE: &str = "Usage: apply-part [options] >out.mesh";
+const USAGE: &str = "Usage: apply-part [options] [out-mesh] >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
         eprintln!("{}", options.usage(USAGE));
         return Ok(());
     }
-    if !matches.free.is_empty() {
+    if matches.free.len() > 1 {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
             .for_each(|((_, _, element_ref), part)| *element_ref = part as isize);
     }
 
-    coupe_tools::write_mesh(&mesh, format)?;
+    coupe_tools::write_mesh(&mesh, format, matches.free.get(0))?;
 
     Ok(())
 }

--- a/tools/src/bin/apply-weight.rs
+++ b/tools/src/bin/apply-weight.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::fs;
 use std::io;
 
-const USAGE: &str = "Usage: apply-weight [options] >out.mesh";
+const USAGE: &str = "Usage: apply-weight [options] [out-mesh] >out.mesh";
 
 fn apply(mesh: &mut Mesh, weights: impl Iterator<Item = isize>) {
     if let Some(element_dim) = mesh
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         eprintln!("{}", options.usage(USAGE));
         return Ok(());
     }
-    if !matches.free.is_empty() {
+    if matches.free.len() > 1 {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
         }
     }
 
-    coupe_tools::write_mesh(&mesh, format)?;
+    coupe_tools::write_mesh(&mesh, format, matches.free.get(0))?;
 
     Ok(())
 }

--- a/tools/src/bin/mesh-dup.rs
+++ b/tools/src/bin/mesh-dup.rs
@@ -1,10 +1,8 @@
 use anyhow::Context as _;
 use anyhow::Result;
-use mesh_io::Mesh;
 use std::env;
-use std::io;
 
-const USAGE: &str = "Usage: mesh-dup [options] <in.mesh >out.mesh";
+const USAGE: &str = "Usage: mesh-dup [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
@@ -18,7 +16,7 @@ fn main() -> Result<()> {
         eprintln!("{}", options.usage(USAGE));
         return Ok(());
     }
-    if !matches.free.is_empty() {
+    if matches.free.len() > 2 {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
@@ -32,11 +30,9 @@ fn main() -> Result<()> {
         .context("invalid value for option 'times'")?
         .unwrap_or(2);
 
-    let stdin = io::stdin();
-    let stdin = stdin.lock();
-    let stdin = io::BufReader::new(stdin);
-    let mesh = Mesh::from_reader(stdin).context("failed to read mesh")?;
-    coupe_tools::write_mesh(&mesh.duplicate(n), format)?;
+    let mesh = coupe_tools::read_mesh(matches.free.get(0))?;
+    let mesh = mesh.duplicate(n);
+    coupe_tools::write_mesh(&mesh, format, matches.free.get(1))?;
 
     Ok(())
 }

--- a/tools/src/bin/mesh-refine.rs
+++ b/tools/src/bin/mesh-refine.rs
@@ -1,10 +1,8 @@
 use anyhow::Context as _;
 use anyhow::Result;
-use mesh_io::Mesh;
 use std::env;
-use std::io;
 
-const USAGE: &str = "Usage: mesh-refine [options] <in.mesh >out.mesh";
+const USAGE: &str = "Usage: mesh-refine [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
@@ -23,7 +21,7 @@ fn main() -> Result<()> {
         eprintln!("{}", options.usage(USAGE));
         return Ok(());
     }
-    if !matches.free.is_empty() {
+    if matches.free.len() > 2 {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
@@ -38,10 +36,7 @@ fn main() -> Result<()> {
         .unwrap_or(1);
 
     eprintln!("Reading mesh...");
-    let stdin = io::stdin();
-    let stdin = stdin.lock();
-    let stdin = io::BufReader::new(stdin);
-    let mut mesh = Mesh::from_reader(stdin).context("failed to read mesh")?;
+    let mut mesh = coupe_tools::read_mesh(matches.free.get(0))?;
     eprintln!(" -> Dimension: {}", mesh.dimension());
     eprintln!(" -> Nodes: {}", mesh.node_count());
     eprintln!(" -> Elements: {}", mesh.element_count());
@@ -56,7 +51,7 @@ fn main() -> Result<()> {
     eprintln!(" -> Elements: {}", mesh.element_count());
 
     eprintln!("Writing mesh...");
-    coupe_tools::write_mesh(&mesh, format)?;
+    coupe_tools::write_mesh(&mesh, format, matches.free.get(1))?;
 
     Ok(())
 }

--- a/tools/src/bin/mesh-reorder.rs
+++ b/tools/src/bin/mesh-reorder.rs
@@ -2,9 +2,8 @@ use anyhow::Context as _;
 use anyhow::Result;
 use mesh_io::Mesh;
 use std::env;
-use std::io;
 
-const USAGE: &str = "Usage: mesh-reorder [options] <in.mesh >out.mesh";
+const USAGE: &str = "Usage: mesh-reorder [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
 fn shuffle_couple<R, T>(mut rng: R, data: &[T], refs: &[isize]) -> (Vec<T>, Vec<isize>, Vec<usize>)
 where
@@ -72,7 +71,7 @@ fn main() -> Result<()> {
         eprintln!("{}", options.usage(USAGE));
         return Ok(());
     }
-    if !matches.free.is_empty() {
+    if matches.free.len() > 2 {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
@@ -82,16 +81,13 @@ fn main() -> Result<()> {
         .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
 
     eprintln!("Reading mesh...");
-    let stdin = io::stdin();
-    let stdin = stdin.lock();
-    let stdin = io::BufReader::new(stdin);
-    let mut mesh = Mesh::from_reader(stdin).unwrap();
+    let mut mesh = coupe_tools::read_mesh(matches.free.get(0))?;
 
     eprintln!("Shuffling mesh...");
     mesh = shuffle(rand::thread_rng(), mesh);
 
     eprintln!("Writing mesh...");
-    coupe_tools::write_mesh(&mesh, format)?;
+    coupe_tools::write_mesh(&mesh, format, matches.free.get(1))?;
 
     Ok(())
 }


### PR DESCRIPTION
Both following invocations are now accepted:

    weight-gen -d constant,1 mesh weights
    weight-gen -d constant,1 <mesh >weights

To read from stdin and write to a file, you can use "-" (as most command-line utilities do):

    weight-gen -d constant,1 - weights <mesh


Closes #229 