### PR TITLE
meshio/ffi: use std's c_int instead of libc's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,6 @@ dependencies = [
 name = "mesh-io-ffi"
 version = "0.1.0"
 dependencies = [
- "libc",
  "mesh-io",
 ]
 

--- a/tools/mesh-io/ffi/Cargo.toml
+++ b/tools/mesh-io/ffi/Cargo.toml
@@ -18,4 +18,3 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 mesh-io = { version = "0.1", path = ".." }
-libc = "0.2"

--- a/tools/mesh-io/ffi/src/lib.rs
+++ b/tools/mesh-io/ffi/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)] // See `meshio.h`.
 
-use libc::c_int;
 use mesh_io::Mesh;
+use std::ffi::c_int;
 use std::fs;
 use std::io;
 use std::mem;


### PR DESCRIPTION
std defines std::ffi::c_int and std::os::raw::c_int, however the later module is marked as deprecated?