### PR TITLE
tools: infer mesh format from extension

### DIFF
--- a/tools/doc/apply-part.1.scd
+++ b/tools/doc/apply-part.1.scd
@@ -28,8 +28,8 @@ Only some specific mesh formats are supported.  See *INPUT FORMAT* for details.
 	Show a help message and exit.
 
 *-f, --format* <format>
-	Set the output format.  See *OUTPUT FORMAT* for the list of accepted
-	values.
+	Override the output format.  By default, the file format is inferred from
+	the file extension.  See *OUTPUT FORMAT* for more info.
 
 *-m, --mesh* <path>
 	Use the given mesh file as template.

--- a/tools/doc/mesh-dup.1.scd
+++ b/tools/doc/mesh-dup.1.scd
@@ -25,8 +25,8 @@ FORMAT* for details.
 	Show a help message and exit.
 
 *-f, --format* <format>
-	Set the output format.  See *apply-part(1)*'s *OUTPUT FORMAT* for the list
-	of accepted values.
+	Override the output format.  By default, the file format is inferred from
+	the file extension.  See *apply-part(1)*'s *OUTPUT FORMAT* for more info.
 
 *-n, --times* <n>
 	Iterate a given number of times.  By default, only once.

--- a/tools/doc/mesh-refine.1.scd
+++ b/tools/doc/mesh-refine.1.scd
@@ -29,8 +29,8 @@ FORMAT* for details.
 	Show a help message and exit.
 
 *-f, --format* <format>
-	Set the output format.  See *apply-part(1)*'s *OUTPUT FORMAT* for the list
-	of accepted values.
+	Override the output format.  By default, the file format is inferred from
+	the file extension.  See *apply-part(1)*'s *OUTPUT FORMAT* for more info.
 
 *-n, --times* <n>
 	Iterate a given number of times.  By default, only once.

--- a/tools/doc/mesh-reorder.1.scd
+++ b/tools/doc/mesh-reorder.1.scd
@@ -29,8 +29,8 @@ FORMAT* for details.
 	Show a help message and exit.
 
 *-f, --format* <format>
-	Set the output format.  See *apply-part(1)*'s *OUTPUT FORMAT* for the list
-	of accepted values.
+	Override the output format.  By default, the file format is inferred from
+	the file extension.  See *apply-part(1)*'s *OUTPUT FORMAT* for more info.
 
 # SEE ALSO
 

--- a/tools/src/bin/apply-part.rs
+++ b/tools/src/bin/apply-part.rs
@@ -24,10 +24,9 @@ fn main() -> Result<()> {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
-    let format: coupe_tools::MeshFormat = matches
+    let format = matches
         .opt_get("f")
-        .context("invalid value for option 'format'")?
-        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+        .context("invalid value for option 'format'")?;
 
     let mesh_file = matches
         .opt_str("m")

--- a/tools/src/bin/apply-weight.rs
+++ b/tools/src/bin/apply-weight.rs
@@ -41,10 +41,9 @@ fn main() -> Result<()> {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
-    let format: coupe_tools::MeshFormat = matches
+    let format = matches
         .opt_get("f")
-        .context("invalid value for option 'format'")?
-        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+        .context("invalid value for option 'format'")?;
 
     let mesh_file = matches
         .opt_str("m")

--- a/tools/src/bin/mesh-dup.rs
+++ b/tools/src/bin/mesh-dup.rs
@@ -20,10 +20,9 @@ fn main() -> Result<()> {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
-    let format: coupe_tools::MeshFormat = matches
+    let format = matches
         .opt_get("f")
-        .context("invalid value for option 'format'")?
-        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+        .context("invalid value for option 'format'")?;
 
     let n: usize = matches
         .opt_get("n")

--- a/tools/src/bin/mesh-refine.rs
+++ b/tools/src/bin/mesh-refine.rs
@@ -25,10 +25,9 @@ fn main() -> Result<()> {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
-    let format: coupe_tools::MeshFormat = matches
+    let format = matches
         .opt_get("f")
-        .context("invalid value for option 'format'")?
-        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+        .context("invalid value for option 'format'")?;
 
     let n: usize = matches
         .opt_get("n")

--- a/tools/src/bin/mesh-reorder.rs
+++ b/tools/src/bin/mesh-reorder.rs
@@ -75,10 +75,9 @@ fn main() -> Result<()> {
         anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
     }
 
-    let format: coupe_tools::MeshFormat = matches
+    let format = matches
         .opt_get("f")
-        .context("invalid value for option 'format'")?
-        .unwrap_or(coupe_tools::MeshFormat::MeditBinary);
+        .context("invalid value for option 'format'")?;
 
     eprintln!("Reading mesh...");
     let mut mesh = coupe_tools::read_mesh(matches.free.get(0))?;


### PR DESCRIPTION
So the following invocations will produce a VTK ASCII file and a MEDIT binary file respectively:

    apply-weight -m my_mesh.vtk -w weights.dat my_mesh_with_weights.vtk
    mesh-refine my_mesh.vtk refined_mesh.meshb