### PR TITLE
hilbert: add a simple 3D implementation

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     //      +---+---+       +---+---+
     //     0    3    6     1    2    3
     //
-    let coordinates: [Point2D; 9] = [
+    let coordinates: &[Point2D] = &[
         Point2D::new(0.0, 0.0),
         Point2D::new(0.0, 1.0),
         Point2D::new(0.0, 2.0),

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -379,7 +379,8 @@ pub unsafe extern "C" fn coupe_hilbert(
             Err(_) => return Error::Alloc,
         };
 
-        let res = coupe::HilbertCurve { part_count, order }.partition(partition, (points, weights));
+        let res =
+            coupe::HilbertCurve { part_count, order }.partition(partition, (&*points, weights));
 
         match res {
             Ok(()) => Error::Ok,

--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -59,28 +59,6 @@ fn hilbert_curve_partition(
         });
 }
 
-#[allow(unused)]
-pub(crate) fn hilbert_curve_reorder(points: &[Point2D], order: usize) -> Vec<usize> {
-    let mut permutation: Vec<usize> = (0..points.len()).into_par_iter().collect();
-    hilbert_curve_reorder_permu(points, &mut permutation, order);
-    permutation
-}
-
-/// Reorder a set of points and weights following the hilbert curve technique.
-/// First, the minimal bounding rectangle of the set of points is computed and local
-/// coordinated are defined on it: the mbr is seen as [0; 2^order - 1]^2.
-/// Then the hilbert curve is computed from those local coordinates.
-fn hilbert_curve_reorder_permu(points: &[Point2D], permutation: &mut [usize], order: usize) {
-    debug_assert!(order < 32);
-
-    let compute_hilbert_index = hilbert_index_computer(points, order);
-
-    permutation.par_sort_by_key(|idx| {
-        let p = &points[*idx];
-        compute_hilbert_index(p)
-    });
-}
-
 /// Compute a mapping from [min; max] to [0; 2**order-1]
 fn segment_to_segment(min: f64, max: f64, order: usize) -> impl Fn(f64) -> u64 {
     debug_assert!(min <= max);

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -236,20 +236,36 @@ impl<const D: usize> ToRunner<D> for coupe::Rcb {
 impl<const D: usize> ToRunner<D> for coupe::HilbertCurve {
     fn to_runner<'a>(&'a mut self, problem: &'a Problem<D>) -> Runner<'a> {
         use weight::Array::*;
-        if D != 2 {
-            return runner_error("hilbert is only implemented for 2D meshes");
-        }
-        // SAFETY: is a noop since D == 2
-        let points = unsafe { mem::transmute::<&[PointND<D>], &[PointND<2>]>(problem.points()) };
-        match &problem.weights {
-            Integers(_) => runner_error("hilbert is only implemented for floats"),
-            Floats(fs) => {
-                let weights: Vec<f64> = fs.iter().map(|weight| weight[0]).collect();
-                Box::new(move |partition| {
-                    self.partition(partition, (points, &weights))?;
-                    Ok(None)
-                })
+        if D == 2 {
+            // SAFETY: is a noop since D == 2
+            let points =
+                unsafe { mem::transmute::<&[PointND<D>], &[PointND<2>]>(problem.points()) };
+            match &problem.weights {
+                Integers(_) => runner_error("hilbert is only implemented for floats"),
+                Floats(fs) => {
+                    let weights: Vec<f64> = fs.iter().map(|weight| weight[0]).collect();
+                    Box::new(move |partition| {
+                        self.partition(partition, (points, &weights))?;
+                        Ok(None)
+                    })
+                }
             }
+        } else if D == 3 {
+            // SAFETY: is a noop since D == 3
+            let points =
+                unsafe { mem::transmute::<&[PointND<D>], &[PointND<3>]>(problem.points()) };
+            match &problem.weights {
+                Integers(_) => runner_error("hilbert is only implemented for floats"),
+                Floats(fs) => {
+                    let weights: Vec<f64> = fs.iter().map(|weight| weight[0]).collect();
+                    Box::new(move |partition| {
+                        self.partition(partition, (points, &weights))?;
+                        Ok(None)
+                    })
+                }
+            }
+        } else {
+            runner_error("hilbert is only implemented for 2D and 3D meshes")
         }
     }
 }


### PR DESCRIPTION
The 3D implementation needs a smaller lookup table, because there is
twice as many configurations to go from an order to the next. Therefore,
the LUT allow for only 3 bit to be computed at a time (instead of 6).
Its layout is similar however, configurations are encoded on 3 bits
instead of 2.

To prevent trait implementation conflicts, HilbertCurve can only
implement Partition for &[PointND] instead of all P: AsRef<[_]>.

cube split in 5 equal parts

![image](https://user-images.githubusercontent.com/51088794/193003928-ef23a2bf-7910-4633-9289-ab84f196fc19.png)