### PR TITLE
ci: update to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust:
@@ -34,7 +34,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust:
@@ -60,7 +60,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -76,7 +76,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: sudo apt-get -y install libclang-dev libmetis-dev libscotch-dev
       - uses: actions/checkout@v2

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: sudo apt-get -y install libclang-dev libmetis-dev libscotch-dev


### PR DESCRIPTION
Mainly to update mandoc, since the generated pages are missing some newlines.

ubuntu-latest still points to 20.04 [0], so we'll have to pin to 22.04.

[0] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources