### PR TITLE
hilbert: add ref to Multi-Jagged paper

### DIFF
--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -491,6 +491,10 @@ impl std::error::Error for Error {}
 ///
 /// rawunprotected. *LUT-based 3D Hilbert curves*.
 /// <http://threadlocalmutex.com/?p=149>
+///
+/// Deveci, M. et al., 2016. Multi-Jagged: A Scalable Parallel Spatial
+/// Partitioning Algorithm. *IEEE Transactions on Parallel and Distributed
+/// Systems*, 27(3), pp. 803–817. <https://doi.org/10.1109/TPDS.2015.2412545>
 #[derive(Clone, Copy, Debug)]
 pub struct HilbertCurve {
     pub part_count: usize,


### PR DESCRIPTION
Since it's using the 1DPART algorithm from said paper.

Cherry-picked from a local commit i made for #243