### PR TITLE
tools: free mesh when runners have been built

### DIFF
--- a/tools/src/bin/part-bench.rs
+++ b/tools/src/bin/part-bench.rs
@@ -198,6 +198,8 @@ where
             algorithm.to_runner(&problem)
         })
         .collect();
+    std::mem::drop(problem); // free memory from mesh
+
     let mut benchmark = || {
         let _task = coupe_tools::ittapi::begin(&intel_domain, "benchmark-iteration");
 

--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -11,8 +11,9 @@ pub struct Recursive {
 }
 
 impl<const D: usize> ToRunner<D> for Recursive {
-    fn to_runner<'a>(&'a mut self, problem: &'a Problem<D>) -> Runner<'a> {
-        let (ncon, mut weights) = match &problem.weights {
+    fn to_runner<'a>(&'a mut self, problem: &Problem<D>) -> Runner<'a> {
+        let weights = problem.weights();
+        let (ncon, mut weights) = match &*weights {
             weight::Array::Integers(is) => {
                 let ncon = is.first().map_or(1, Vec::len) as Idx;
                 let weights = crate::zoom_in(is.iter().map(|v| v.iter().cloned()));
@@ -25,7 +26,8 @@ impl<const D: usize> ToRunner<D> for Recursive {
             }
         };
 
-        let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
+        let adjacency = problem.adjacency();
+        let (xadj, adjncy, adjwgt) = adjacency.view().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
         let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
@@ -57,8 +59,9 @@ pub struct KWay {
 }
 
 impl<const D: usize> ToRunner<D> for KWay {
-    fn to_runner<'a>(&'a mut self, problem: &'a Problem<D>) -> Runner<'a> {
-        let (ncon, mut weights) = match &problem.weights {
+    fn to_runner<'a>(&'a mut self, problem: &Problem<D>) -> Runner<'a> {
+        let weights = problem.weights();
+        let (ncon, mut weights) = match &*weights {
             weight::Array::Integers(is) => {
                 let ncon = is.first().map_or(1, Vec::len) as Idx;
                 let weights = crate::zoom_in(is.iter().map(|v| v.iter().cloned()));
@@ -71,7 +74,8 @@ impl<const D: usize> ToRunner<D> for KWay {
             }
         };
 
-        let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
+        let adjacency = problem.adjacency();
+        let (xadj, adjncy, adjwgt) = adjacency.view().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
         let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));

--- a/tools/src/scotch.rs
+++ b/tools/src/scotch.rs
@@ -12,8 +12,9 @@ pub struct Standard {
 }
 
 impl<const D: usize> ToRunner<D> for Standard {
-    fn to_runner<'a>(&'a mut self, problem: &'a Problem<D>) -> super::Runner<'a> {
-        let weights = match &problem.weights {
+    fn to_runner<'a>(&'a mut self, problem: &Problem<D>) -> super::Runner<'a> {
+        let weights = problem.weights();
+        let weights = match &*weights {
             weight::Array::Integers(is) => {
                 if is.first().map_or(1, Vec::len) != 1 {
                     return runner_error("SCOTCH cannot do multi-criteria partitioning");
@@ -28,7 +29,8 @@ impl<const D: usize> ToRunner<D> for Standard {
             }
         };
 
-        let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
+        let adjacency = problem.adjacency();
+        let (xadj, adjncy, adjwgt) = adjacency.view().into_raw_storage();
         let xadj: Vec<_> = xadj.iter().map(|i| *i as Num).collect();
         let adjncy: Vec<_> = adjncy.iter().map(|i| *i as Num).collect();
         let adjwgt = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));


### PR DESCRIPTION
Avoid having both the mesh and runners' data living in memory when algorithms run.  This leaves a bit more room for algorithms.

This is a quick hack for the 1- and 10- billion cell runs. Ultimately I'd like to change the `Problem` API to make it less clunky.