### PR TITLE
hilbert: implement zorder for archs other than x86_64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ version = "0.1.0"
 dependencies = [
  "affinity",
  "approx",
+ "cfg-if",
  "criterion",
  "itertools",
  "ittapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ avx512 = []
 
 [dependencies]
 approx = "0.5"
+cfg-if = "1.0"
 itertools = "0.10"
 nalgebra = { version = "0.29", default-features = false, features = ["rand", "std"] }
 num-traits = "0.2"


### PR DESCRIPTION
- for x86: use twice as many `pdep32`s and OR the results,
- for other archs: loop over the bits. I didn't measure the performance.

Don't need this for now, and fallback code compiles to a lot of instructions, so I'll keep this PR open

Fixes #260

### TODO

- [ ] unit tests