### PR TITLE
ci: update to codecov@v3 to fix github warning

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
         run: cargo +nightly llvm-cov --doctests --lcov --no-default-features --workspace --output-path lcov.info
         # no default because we lack scotch and metis
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
<https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/>

Example warning:
https://github.com/LIHPC-Computational-Geometry/coupe/actions/runs/3541583767