### PR TITLE
arcswap: lock vertex *before* gain calculations (and other things)

### DIFF
--- a/src/algorithms/arc_swap.rs
+++ b/src/algorithms/arc_swap.rs
@@ -10,9 +10,7 @@ use rayon::iter::IndexedParallelIterator as _;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
 use rayon::slice::ParallelSlice;
-use std::mem;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 /// Diagnostic data for a [ArcSwap] run.
@@ -112,7 +110,7 @@ where
     let span = tracing::info_span!("doing moves");
     let _enter = span.enter();
 
-    let partition = unsafe { mem::transmute::<&mut [usize], &[AtomicUsize]>(partition) };
+    let partition = crate::as_atomic(partition);
 
     // This function makes move attempts until either
     // - `cut` is empty, or

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -1113,28 +1113,4 @@ mod tests {
         assert_eq!(p3.count(), 2);
         assert_eq!(p4.count(), 2);
     }
-
-    //#[test] // Disabled by default because of its need for a random source.
-    fn _test_rcb_rand() {
-        use std::collections::HashMap;
-
-        let points: Vec<Point2D> = (0..40000)
-            .map(|_| Point2D::from([rand::random(), rand::random()]))
-            .collect();
-        let weights: Vec<f64> = (0..points.len()).map(|_| rand::random()).collect();
-
-        let mut partition = vec![0; points.len()];
-        rcb(&mut partition, points, weights.par_iter().cloned(), 3, 0.05).unwrap();
-
-        let mut loads: HashMap<usize, f64> = HashMap::new();
-        let mut sizes: HashMap<usize, usize> = HashMap::new();
-        for (weight_id, part) in partition.iter().enumerate() {
-            let weight = weights[weight_id];
-            *loads.entry(*part).or_default() += weight;
-            *sizes.entry(*part).or_default() += 1;
-        }
-        for ((part, load), size) in loads.iter().zip(sizes.values()) {
-            println!("{part:?} -> {size}:{load:.1}");
-        }
-    }
 }

--- a/src/algorithms/recursive_bisection.rs
+++ b/src/algorithms/recursive_bisection.rs
@@ -679,15 +679,7 @@ where
     });
     let mut weights: Vec<_> = weights.collect();
 
-    let atomic_partition = unsafe {
-        // Rust does not seem to have a strict aliasing rule like C does, so the
-        // transmute here looks safe, but we still need to ensure partition is
-        // properly aligned for atomic types. While this should always be the
-        // case, better safe than sorry.
-        let (before, partition, after) = partition.align_to_mut::<AtomicUsize>();
-        assert!(before.is_empty() && after.is_empty());
-        &*partition
-    };
+    let atomic_partition = crate::as_atomic(partition);
     let mut atomic_partition: Vec<&AtomicUsize> = atomic_partition.par_iter().collect();
     let sum = weights.par_iter().cloned().sum();
     let bb = match BoundingBox::from_points(points) {

--- a/src/average.rs
+++ b/src/average.rs
@@ -22,3 +22,19 @@ macro_rules! impl_int {
 
 impl_int!(i64);
 impl_int!(u64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_int() {
+        assert_eq!(i64::avg(i64::MAX, i64::MAX - 2), i64::MAX - 1);
+        assert_eq!(u64::avg(u64::MAX, u64::MAX - 2), u64::MAX - 1);
+    }
+
+    #[test]
+    fn test_float() {
+        assert_eq!(f64::avg(1e308, 1e307), 5.5e307);
+    }
+}


### PR DESCRIPTION
Otherwise there can be concurrent moves on neighbors V and U when:

1. Thread A computes the gain of V
2. Thread B computes the gain of U
3. Thread A locks V
4. Thread A checks for locks on neighbors of V
    -> there are none because B didn't lock U yet
5. Thread A moves V and releases the lock
6. Thread B locks U
7. Thread B checks for locks on neighbors of U
    -> there are none because A released the lock
8. Thread B moves U