### PR TITLE
imbalance: fix divisions by zero

### DIFF
--- a/src/imbalance.rs
+++ b/src/imbalance.rs
@@ -50,9 +50,20 @@ where
     let weights = weights.into_par_iter();
     debug_assert_eq!(partition.len(), weights.len());
 
+    if num_parts == 0 {
+        // Avoid a division by zero.
+        return 0.0;
+    }
+
     let part_loads = compute_parts_load(partition, num_parts, weights);
     let total_weight: W::Item = part_loads.iter().cloned().sum();
+
     let ideal_part_weight = total_weight.to_f64().unwrap() / num_parts.to_f64().unwrap();
+    if ideal_part_weight == 0.0 {
+        // Avoid divisions by zero.
+        return 0.0;
+    }
+
     part_loads
         .into_iter()
         .map(|part_weight| {

--- a/tools/src/bin/part-info.rs
+++ b/tools/src/bin/part-info.rs
@@ -72,6 +72,10 @@ where
     T: FromPrimitive + ToPrimitive + Zero + PartialOrd,
     T: std::ops::Div<Output = T> + std::ops::Sub<Output = T> + std::iter::Sum,
 {
+    if part_count == 0 {
+        // Avoid divisions by zero.
+        return Vec::new();
+    }
     let criterion_count = match weights.first() {
         Some(w) => w.len(),
         None => return Vec::new(),


### PR DESCRIPTION
If all weights are zero or if num_parts is zero, the return value is NaN. Let's return zero instead because why not it seems sensible.

Also add the fix to part-info.