### PR TITLE
it seems drop is part of std::prelude?

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -16,7 +16,6 @@ use coupe::Point2D;
 use coupe::PointND;
 use coupe::Real;
 use std::ffi::c_void;
-use std::mem;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr;
@@ -114,7 +113,7 @@ pub extern "C" fn coupe_strerror(err: Error) -> *const c_char {
 pub unsafe extern "C" fn coupe_data_free(data: *mut Data) {
     if !data.is_null() {
         let data = Box::from_raw(data);
-        mem::drop(data);
+        drop(data);
     }
 }
 
@@ -165,7 +164,7 @@ pub enum Adjncy<'a> {
 pub unsafe extern "C" fn coupe_adjncy_free(adjncy: *mut Adjncy) {
     if !adjncy.is_null() {
         let adjncy = Box::from_raw(adjncy);
-        mem::drop(adjncy);
+        drop(adjncy);
     }
 }
 

--- a/src/algorithms/hilbert_curve.rs
+++ b/src/algorithms/hilbert_curve.rs
@@ -20,7 +20,6 @@ use num_traits::NumAssign;
 use rayon::prelude::*;
 use std::fmt;
 use std::iter::Sum;
-use std::mem;
 
 /// Divide `points` into `n` parts of similar weights.
 ///
@@ -177,13 +176,13 @@ fn partition_indexed<const D: usize>(
 
     let hilbert_indices: Vec<u64> = points.par_iter().map(index_fn).collect();
 
-    mem::drop(enter);
+    drop(enter);
     let span = tracing::info_span!("computing split positions");
     let enter = span.enter();
 
     let split_positions = weighted_quantiles(&hilbert_indices, weights, part_count);
 
-    mem::drop(enter);
+    drop(enter);
     let span = tracing::info_span!("apply part ids");
     let _enter = span.enter();
 

--- a/tools/mesh-io/src/medit/parser.rs
+++ b/tools/mesh-io/src/medit/parser.rs
@@ -5,7 +5,6 @@ use std::cell;
 use std::error;
 use std::fmt;
 use std::io;
-use std::mem;
 use std::num;
 use std::str;
 
@@ -225,7 +224,7 @@ pub fn parse_ascii<R: io::BufRead>(mut input: R) -> Result<Mesh, Error> {
             lineno: *lineno.borrow(),
         });
     }
-    mem::drop(header); // drop the borrow on token
+    drop(header); // drop the borrow on token
 
     let _version_number = read(T)
         .map_err(with_lineno(*lineno.borrow()))?
@@ -242,7 +241,7 @@ pub fn parse_ascii<R: io::BufRead>(mut input: R) -> Result<Mesh, Error> {
             lineno: *lineno.borrow(),
         });
     }
-    mem::drop(dimension_keyword); // drop the borrow on token
+    drop(dimension_keyword); // drop the borrow on token
 
     let dimension = read(T)
         .map_err(with_lineno(*lineno.borrow()))?
@@ -260,7 +259,7 @@ pub fn parse_ascii<R: io::BufRead>(mut input: R) -> Result<Mesh, Error> {
         match section.as_str() {
             "end" => break,
             "vertices" => {
-                mem::drop(section); // drop the borrow on token
+                drop(section); // drop the borrow on token
 
                 let num_vertices = read(T)
                     .map_err(with_lineno(*lineno.borrow()))?
@@ -303,7 +302,7 @@ pub fn parse_ascii<R: io::BufRead>(mut input: R) -> Result<Mesh, Error> {
             }
             element_type if element_type.parse::<ElementType>().is_ok() => {
                 let element_type = element_type.parse::<ElementType>().unwrap();
-                mem::drop(section); // drop the borrow on token
+                drop(section); // drop the borrow on token
 
                 let prev_lineno = *lineno.borrow();
                 let num_entries = loop {
@@ -350,7 +349,7 @@ pub fn parse_ascii<R: io::BufRead>(mut input: R) -> Result<Mesh, Error> {
                 mesh.topology.push((element_type, vertices, refs));
             }
             "corners" | "ridges" | "requiredvertices" => {
-                mem::drop(section); // drop the borrow on token
+                drop(section); // drop the borrow on token
                 let num_entries = read(T)
                     .map_err(with_lineno(*lineno.borrow()))?
                     .parse::<usize>()

--- a/tools/src/bin/mesh-part.rs
+++ b/tools/src/bin/mesh-part.rs
@@ -12,7 +12,6 @@ use mesh_io::Mesh;
 use std::env;
 use std::fs;
 use std::io;
-use std::mem::drop;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;


### PR DESCRIPTION
You don't need to "use std::mem::drop;"...