### PR TITLE
CI: Fix docker linter step

### DIFF
--- a/.github/workflows/docker-publish-nightly.yml
+++ b/.github/workflows/docker-publish-nightly.yml
@@ -42,6 +42,7 @@ jobs:
         uses: hadolint/hadolint-action@master
         with:
           dockerfile: "Dockerfile"
+          ignore: 'DL3006,DL3008' # DL3006: false positive, rust image has a tag
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@master
+        with:
+          dockerfile: "Dockerfile"
+          ignore: 'DL3006,DL3008' # DL3006: false positive, rust image has a tag
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /builder
 
 COPY . .
 
-RUN apt-get update -y && apt-get install -y libclang-dev libmetis-dev libscotch-dev
+RUN apt-get update -y && apt-get install -y --no-install-recommends libclang-dev libmetis-dev libscotch-dev
 
 ARG BINDGEN_EXTRA_CLANG_ARGS="-I/usr/include/scotch"
 


### PR DESCRIPTION
Fix Dockerfile linter step in docker publish nightly workflow by adding ignore rules :

- DL3006: false positive due to the builder pattern used
- DL3008: afaik, we don't want to pin versions in apt get install

Other changes:

- avoid additional packages by specifying `--no-install-recommends` in Dockerfiler
- add Dockerfile linter step to manual build action