### PR TITLE
cartesian: fix partition being transposed

### DIFF
--- a/src/cartesian/mod.rs
+++ b/src/cartesian/mod.rs
@@ -143,7 +143,7 @@ impl Grid<2> {
         );
         partition.par_iter_mut().enumerate().for_each(|(i, p)| {
             let pos = self.position_of(i);
-            *p = iters.part_of(pos, 0);
+            *p = iters.part_of(pos, 1);
         });
     }
 }
@@ -175,7 +175,7 @@ impl Grid<3> {
         );
         partition.par_iter_mut().enumerate().for_each(|(i, p)| {
             let pos = self.position_of(i);
-            *p = iters.part_of(pos, 0);
+            *p = iters.part_of(pos, 1);
         });
     }
 }

--- a/tools/num-part/src/database/mod.rs
+++ b/tools/num-part/src/database/mod.rs
@@ -34,8 +34,8 @@ fn upgrade_schema(database: &mut rusqlite::Connection) -> Result<()> {
         "Upgrading database from version {} to version {}",
         db_version, my_version
     );
-    for v in db_version..my_version {
-        tx.execute_batch(MIGRATIONS[v as usize])
+    for (v, migration) in MIGRATIONS[db_version..my_version].iter().enumerate() {
+        tx.execute_batch(migration)
             .with_context(|| format!("failed to execute migration #{}", v))?;
     }
 

--- a/tools/src/bin/mesh-part.rs
+++ b/tools/src/bin/mesh-part.rs
@@ -138,7 +138,7 @@ fn main() -> Result<()> {
     let weight_file = matches
         .opt_str("w")
         .context("missing required option 'weights'")?;
-    let weights = fs::File::open(&weight_file).context("failed to open weight file")?;
+    let weights = fs::File::open(weight_file).context("failed to open weight file")?;
     let weights = io::BufReader::new(weights);
 
     let (mesh, weights) = rayon::join(

--- a/tools/src/bin/part-bench.rs
+++ b/tools/src/bin/part-bench.rs
@@ -287,7 +287,7 @@ fn main() -> Result<()> {
     let weight_file = matches
         .opt_str("w")
         .context("missing required option 'weights'")?;
-    let weights = fs::File::open(&weight_file).context("failed to open weight file")?;
+    let weights = fs::File::open(weight_file).context("failed to open weight file")?;
     let weights = io::BufReader::new(weights);
 
     build_global_pool();

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -426,7 +426,7 @@ where
             part_count: require(parse(args.next()))?,
             order: optional(parse(args.next()), 12)?,
         }),
-        "kmeans" => Box::new(coupe::KMeans::default()),
+        "kmeans" => Box::<coupe::KMeans>::default(),
         "arcswap" => {
             let max_imbalance = parse(args.next()).transpose()?;
             Box::new(coupe::ArcSwap { max_imbalance })


### PR DESCRIPTION
Since we start with coord=1, Grid::part_of must also be called with coord=1, otherwise the partition array ends up being transposed.