### PR TITLE
tools: add a mesh-points utility

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -21,7 +21,8 @@ includes the following tools:
       tools,
     - mesh-dup and mesh-refine increase the size of a mesh by either duplicating
       the vertices or splitting its elements into smaller ones, respectively,
-    - mesh-reorder changes the order of mesh elements.
+    - mesh-reorder changes the order of mesh elements,
+    - mesh-points extracts the cell centers of a given mesh.
 - in the `report` directory, a collection of shell scripts that aggregate
   results into visual reports:
     - `imbedgecut` generates an SVG graph comparing the imbalance/edge-cut of

--- a/tools/doc/mesh-points.1.scd
+++ b/tools/doc/mesh-points.1.scd
@@ -1,0 +1,59 @@
+mesh-points(1)
+
+# NAME
+
+mesh-points - Extract the cell centers of the given mesh
+
+# SYNOPSIS
+
+*mesh-points* [input.mesh [output.dat]]
+
+# DESCRIPTION
+
+mesh-points extracts the cell centers of the given mesh.
+
+If input.mesh is omitted or is -, it is read from standard input.
+If output.dat is omitted or is -, it is written to standard output.
+
+Only some specific mesh formats are supported.  See *apply-part*(1)'s *INPUT
+FORMAT* for details.
+
+# OPTIONS
+
+*-h, --help*
+	Show a help message and exit.
+
+*--with-ids*
+	Add a column with the cell IDs (refs).
+
+# USAGE EXAMPLE WITH GNUPLOT
+
+Using *--with-ids* on a 3D mesh, one ends up with a file with 4 columns. The
+first three are the cell center coordinates, and the fourth is the cell ID:
+
+```
+1.2 4 6.6 0
+3 12.5 9.01 4
+etc.
+```
+
+Then the gnuplot commands can be used to generate a 3D, colored plot of those
+points:
+
+```
+splot 'mesh.points' using 1:2:3:4 with points palette
+```
+
+# SEE ALSO
+
+*apply-part*(1) *apply-weight*(1)
+
+# AUTHORS
+
+This executable is part of coupe, which is maintained by Hubert Hirtz
+<hubert@hirtz.pm> under the direction of Franck Ledoux <franck.ledoux@cea.fr>
+and the supervision of Cédric Chevalier <cedric.chevalier@cea.fr> and Sébastien
+Morais <sebastien.morais@cea.fr>.
+
+For more information on coupe development, see
+<https://github.com/LIHPC-Computational-Geometry/coupe>.

--- a/tools/src/bin/mesh-points.rs
+++ b/tools/src/bin/mesh-points.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use mesh_io::ElementType;
+use mesh_io::Mesh;
+use std::env;
+use std::io;
+
+const USAGE: &str = "Usage: mesh-points [options] [in-mesh [out-plot]] <in.mesh >out.plot";
+
+fn write_points<const D: usize>(mut w: impl io::Write, mesh: &Mesh, with_ids: bool) -> Result<()> {
+    let points = coupe_tools::barycentres::<D>(mesh);
+    let ids: Box<dyn Iterator<Item = isize>> = if with_ids {
+        Box::new(
+            match mesh
+                .topology()
+                .iter()
+                .map(|(el_type, _, _)| el_type.dimension())
+                .max()
+            {
+                Some(element_dim) => mesh
+                    .elements()
+                    .filter_map(|(element_type, _nodes, element_ref)| {
+                        if element_type.dimension() != element_dim
+                            || element_type == ElementType::Edge
+                        {
+                            return None;
+                        }
+                        Some(element_ref)
+                    })
+                    .collect(),
+                None => Vec::new(),
+            }
+            .into_iter(),
+        )
+    } else {
+        Box::new(std::iter::repeat(0))
+    };
+
+    for (id, point) in ids.zip(points) {
+        for coord in point.into_iter() {
+            write!(w, "{coord} ")?;
+        }
+        if with_ids {
+            write!(w, "{id}")?;
+        }
+        writeln!(w)?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let mut options = getopts::Options::new();
+    options.optflag("h", "help", "print this help menu");
+    options.optflag("", "with-ids", "add a column with the cell id");
+
+    let matches = options.parse(env::args().skip(1))?;
+
+    if matches.opt_present("h") {
+        eprintln!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.free.len() > 2 {
+        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
+    }
+
+    let mesh = coupe_tools::read_mesh(matches.free.get(0))?;
+    let output = coupe_tools::writer(matches.free.get(1))?;
+    let with_ids = matches.opt_present("with-ids");
+    match mesh.dimension() {
+        2 => write_points::<2>(output, &mesh, with_ids)?,
+        3 => write_points::<3>(output, &mesh, with_ids)?,
+        n => anyhow::bail!("expected 2D or 3D mesh, got a {n}D mesh"),
+    };
+
+    Ok(())
+}

--- a/tools/src/bin/mesh-svg.rs
+++ b/tools/src/bin/mesh-svg.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::env;
 use std::io;
 
-const USAGE: &str = "Usage: medit2svg [options] [in-mesh [out-svg]] <in.mesh >out.svg";
+const USAGE: &str = "Usage: mesh-svg [options] [in-mesh [out-svg]] <in.mesh >out.svg";
 
 /// Returns the list of elements that are interesting.
 fn elements(mesh: &Mesh) -> impl Iterator<Item = (ElementType, &[usize], isize)> {


### PR DESCRIPTION
The `--with-ids` argument only works with medit meshes, at least until #288 is fixed.