### PR TITLE
tools: add argument to show version

### DIFF
--- a/tools/build.rs
+++ b/tools/build.rs
@@ -1,0 +1,32 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let git_commit = {
+        let hash = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout;
+        let mut hash = String::from_utf8(hash).unwrap();
+        hash.truncate(7);
+        hash
+    };
+
+    let git_clean_tree = Command::new("git")
+        .args(["status", "-s"])
+        .output()
+        .unwrap()
+        .stdout
+        .is_empty();
+
+    let crate_version = env::var("CARGO_PKG_VERSION").unwrap();
+
+    let coupe_version = if git_clean_tree {
+        format!("{crate_version}-{git_commit}")
+    } else {
+        format!("{crate_version}-{git_commit}+dirty")
+    };
+
+    println!("cargo:rustc-env=COUPE_VERSION={coupe_version}");
+}

--- a/tools/doc/apply-part.1.scd
+++ b/tools/doc/apply-part.1.scd
@@ -27,6 +27,9 @@ Only some specific mesh formats are supported.  See *INPUT FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-f, --format* <format>
 	Override the output format.  By default, the file format is inferred from
 	the file extension.  See *OUTPUT FORMAT* for more info.

--- a/tools/doc/mesh-dup.1.scd
+++ b/tools/doc/mesh-dup.1.scd
@@ -24,6 +24,9 @@ FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-f, --format* <format>
 	Override the output format.  By default, the file format is inferred from
 	the file extension.  See *apply-part*(1)'s *OUTPUT FORMAT* for more info.

--- a/tools/doc/mesh-part.1.scd
+++ b/tools/doc/mesh-part.1.scd
@@ -33,6 +33,9 @@ See *PARTITION FILE* for a description of the output format of mesh-part.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-a, --algorithm* <spec>
 	Apply the given algorithm on the mesh.  This option can be specified
 	multiple times, so that algorithms can be chained together.  See

--- a/tools/doc/mesh-refine.1.scd
+++ b/tools/doc/mesh-refine.1.scd
@@ -28,6 +28,9 @@ FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-f, --format* <format>
 	Override the output format.  By default, the file format is inferred from
 	the file extension.  See *apply-part*(1)'s *OUTPUT FORMAT* for more info.

--- a/tools/doc/mesh-reorder.1.scd
+++ b/tools/doc/mesh-reorder.1.scd
@@ -28,6 +28,9 @@ FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-f, --format* <format>
 	Override the output format.  By default, the file format is inferred from
 	the file extension.  See *apply-part*(1)'s *OUTPUT FORMAT* for more info.

--- a/tools/doc/mesh-svg.1.scd
+++ b/tools/doc/mesh-svg.1.scd
@@ -23,6 +23,9 @@ FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 # SEE ALSO
 
 *apply-part*(1) *apply-weight*(1)

--- a/tools/doc/part-info.1.scd
+++ b/tools/doc/part-info.1.scd
@@ -24,6 +24,9 @@ FORMAT* for details.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-E, --edge-weights* <variant>
 	Change how edge weights are set.  Possible values are listed in
 	*mesh-part*(1).

--- a/tools/doc/weight-gen.1.scd
+++ b/tools/doc/weight-gen.1.scd
@@ -28,6 +28,9 @@ See *WEIGHT FILE* for a description of the output format.
 *-h, --help*
 	Show a help message and exit.
 
+*--version*
+	Show version information and exit.
+
 *-d, --distribution* <spec>
 	Required.  The definition of a weight distribution.  This option must be
 	specified once per criterion.  See *DISTRIBUTION FORMAT* and *SUPPORTED

--- a/tools/src/bin/apply-part.rs
+++ b/tools/src/bin/apply-part.rs
@@ -10,6 +10,7 @@ const USAGE: &str = "Usage: apply-part [options] [out-mesh] >out.mesh";
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("m", "mesh", "mesh file", "FILE");
     options.optopt("p", "partition", "partition file", "FILE");
@@ -17,7 +18,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("apply-part version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 1 {

--- a/tools/src/bin/apply-weight.rs
+++ b/tools/src/bin/apply-weight.rs
@@ -27,6 +27,7 @@ fn apply(mesh: &mut Mesh, weights: impl Iterator<Item = isize>) {
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("m", "mesh", "mesh file", "FILE");
     options.optopt("w", "weights", "weight file", "FILE");
@@ -34,7 +35,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("apply-weight version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 1 {

--- a/tools/src/bin/mesh-dup.rs
+++ b/tools/src/bin/mesh-dup.rs
@@ -7,13 +7,18 @@ const USAGE: &str = "Usage: mesh-dup [options] [in-mesh [out-mesh]] <in.mesh >ou
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("n", "times", "numbers of duplicates (default: 2)", "NUMBER");
 
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("mesh-dup version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 2 {

--- a/tools/src/bin/mesh-part.rs
+++ b/tools/src/bin/mesh-part.rs
@@ -77,6 +77,7 @@ where
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optmulti(
         "a",
         "algorithm",
@@ -97,7 +98,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("mesh-part version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 1 {

--- a/tools/src/bin/mesh-refine.rs
+++ b/tools/src/bin/mesh-refine.rs
@@ -7,6 +7,7 @@ const USAGE: &str = "Usage: mesh-refine [options] [in-mesh [out-mesh]] <in.mesh 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt(
         "n",
@@ -18,7 +19,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("mesh-refine version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 2 {

--- a/tools/src/bin/mesh-reorder.rs
+++ b/tools/src/bin/mesh-reorder.rs
@@ -63,12 +63,17 @@ where
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
 
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("mesh-reorder version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 2 {

--- a/tools/src/bin/mesh-svg.rs
+++ b/tools/src/bin/mesh-svg.rs
@@ -319,6 +319,7 @@ where
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optflag(
         "o",
         "no-optimize",
@@ -328,7 +329,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("mesg-svg version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 2 {

--- a/tools/src/bin/part-bench.rs
+++ b/tools/src/bin/part-bench.rs
@@ -246,6 +246,7 @@ fn main() -> Result<()> {
 
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optmulti(
         "a",
         "algorithm",
@@ -266,7 +267,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("part-bench version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if !matches.free.is_empty() {

--- a/tools/src/bin/part-info.rs
+++ b/tools/src/bin/part-info.rs
@@ -195,6 +195,7 @@ where
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optopt(
         "E",
         "edge-weights",
@@ -209,7 +210,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage("Usage: part-info [options]"));
+        println!("{}", options.usage("Usage: part-info [options]"));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("part-info version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if !matches.free.is_empty() {

--- a/tools/src/bin/weight-gen.rs
+++ b/tools/src/bin/weight-gen.rs
@@ -189,6 +189,7 @@ fn weight_gen<const D: usize>(
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
     options.optflag("h", "help", "print this help menu");
+    options.optflag("", "version", "print version information");
     options.optmulti(
         "d",
         "distribution",
@@ -204,7 +205,11 @@ fn main() -> Result<()> {
     let matches = options.parse(env::args().skip(1))?;
 
     if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
+        println!("{}", options.usage(USAGE));
+        return Ok(());
+    }
+    if matches.opt_present("version") {
+        println!("weight-gen version {}", env!("COUPE_VERSION"));
         return Ok(());
     }
     if matches.free.len() > 2 {


### PR DESCRIPTION
and print help/version on stdout instead of stderr, at least when specifically requested with -h,--help, so that it's easier to pipe into other programs