### PR TITLE
tools: fix integer scaling for metis/scotch

### DIFF
--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -29,15 +29,19 @@ impl<const D: usize> ToRunner<D> for Recursive {
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = zoom_in(adjwgt.iter().map(|v| Some(*v)));
+        let mut adjwgt = zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let tolerance = self.tolerance.map(|f| (f * 1000.0) as Idx);
 
-        let mut metis_partition = vec![0; weights.len()];
+        let mut metis_partition = vec![0; problem.adjacency().rows()];
         Box::new(move |partition| {
-            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy)
-                .set_vwgt(&mut weights)
-                .set_adjwgt(&mut adjwgt);
+            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy);
+            if let Some(weights) = &mut weights {
+                graph = graph.set_vwgt(weights);
+            }
+            if let Some(adjwgt) = &mut adjwgt {
+                graph = graph.set_adjwgt(adjwgt);
+            }
             if let Some(tolerance) = tolerance {
                 graph = graph.set_option(metis::option::UFactor(tolerance));
             }
@@ -75,15 +79,19 @@ impl<const D: usize> ToRunner<D> for KWay {
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = zoom_in(adjwgt.iter().map(|v| Some(*v)));
+        let mut adjwgt = zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let tolerance = self.tolerance.map(|f| (f * 1000.0) as Idx);
 
-        let mut metis_partition = vec![0; weights.len()];
+        let mut metis_partition = vec![0; problem.adjacency().rows()];
         Box::new(move |partition| {
-            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy)
-                .set_vwgt(&mut weights)
-                .set_adjwgt(&mut adjwgt);
+            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy);
+            if let Some(weights) = &mut weights {
+                graph = graph.set_vwgt(weights);
+            }
+            if let Some(adjwgt) = &mut adjwgt {
+                graph = graph.set_adjwgt(adjwgt);
+            }
             if let Some(tolerance) = tolerance {
                 graph = graph.set_option(metis::option::UFactor(tolerance));
             }

--- a/tools/src/scotch.rs
+++ b/tools/src/scotch.rs
@@ -37,9 +37,17 @@ impl<const D: usize> ToRunner<D> for Standard {
         let mut strat = scotch::Strategy::new();
         let arch = scotch::Architecture::complete(self.part_count as Num);
 
-        let mut scotch_partition = vec![0; weights.len()];
+        let mut scotch_partition = vec![0; problem.adjacency().rows()];
         Box::new(move |partition| {
-            let graph_data = Data::new(0, &xadj, &[], &weights, &[], &adjncy, &adjwgt);
+            let graph_data = Data::new(
+                0,
+                &xadj,
+                &[],
+                weights.as_deref().unwrap_or(&[]),
+                &[],
+                &adjncy,
+                adjwgt.as_deref().unwrap_or(&[]),
+            );
             let mut graph = Graph::build(&graph_data).context("failed to build SCOTCH graph")?;
             graph.check().context("failed to build SCOTCH graph")?;
             graph

--- a/tools/src/zoom_in.rs
+++ b/tools/src/zoom_in.rs
@@ -1,42 +1,127 @@
+use coupe::num_traits::NumAssign;
 use coupe::num_traits::PrimInt;
 use coupe::num_traits::ToPrimitive;
-use coupe::num_traits::Zero;
+use itertools::Itertools;
 use std::iter::Sum;
-use std::ops::AddAssign;
 
-pub fn zoom_in<I, O, W>(inputs: I) -> Vec<O>
+/// Scales and offsets the input weights into the bandwidth of type `O`.
+///
+/// This function ensures two things:
+///
+/// - output weights are strictly greater than zero,
+/// - the sum of each criterion is in `O`.
+///
+/// If all weights are the same, returns `None`.
+pub fn zoom_in<I, O, W>(inputs: I) -> Option<Vec<O>>
 where
     I: IntoIterator,
     I::IntoIter: Clone + ExactSizeIterator,
     I::Item: IntoIterator<Item = W>,
-    W: Sum + AddAssign + Clone + Zero + PartialOrd + ToPrimitive,
+    W: Sum + Clone + PartialOrd + ToPrimitive + NumAssign,
     O: PrimInt,
 {
     let inputs = inputs.into_iter();
     let criterion_count = match inputs.clone().next() {
         Some(v) => v.into_iter().count(),
-        None => return Vec::new(),
+        None => return Some(Vec::new()),
     };
-    let sum = inputs
-        .clone()
-        .fold(vec![W::zero(); criterion_count], |mut acc, w| {
-            for (acc, w) in acc.iter_mut().zip(w) {
-                *acc += w;
+    let count = inputs.clone().count();
+
+    // Compensated summation of each criterion.
+    let (mut sums, compensations) = inputs.clone().fold(
+        (vec![0.0; criterion_count], vec![0.0; criterion_count]),
+        |(mut sum, mut compensation), w| {
+            for ((s, w), c) in sum.iter_mut().zip(w).zip(&mut compensation) {
+                let w = w.to_f64().unwrap();
+                let t = *s + w;
+                if f64::abs(w) <= f64::abs(*s) {
+                    *c += (*s - t) + w;
+                } else {
+                    *c += (w - t) + *s;
+                }
+                *s = t;
             }
-            acc
-        })
+            (sum, compensation)
+        },
+    );
+    for (s, c) in sums.iter_mut().zip(compensations) {
+        *s += c;
+    }
+
+    if !sums.iter().all(|s| s.is_finite()) {
+        // At least one of the sum is either infinite or NaN. In this case, just
+        // abort. This can happen when some weights aren't finite, or when their
+        // sum is infinite.
+        // TODO handle the case where all weights are finite but their sum is infinite
+        // TODO return an error somehow, so that the user knows the data is corrupt
+        return None;
+    }
+
+    let sum = sums
         .into_iter()
-        .max_by(|a, b| W::partial_cmp(a, b).unwrap())
+        // won't panic because sums are ensured to be finite
+        .max_by(|a, b| f64::partial_cmp(a, b).unwrap())
         .unwrap();
-    let zoom_factor = (O::max_value() - O::from(inputs.len()).unwrap())
-        .to_f64()
-        .unwrap()
-        / sum.to_f64().unwrap();
-    let _1 = O::one();
-    inputs
+
+    let (min_input, max_input) = inputs.clone().flatten().minmax().into_option().unwrap();
+    let min_input = min_input.to_f64().unwrap();
+    let max_input = max_input.to_f64().unwrap();
+
+    if !f64::is_normal(max_input - min_input) {
+        // Input weight are all (about) the same, don't scale them.
+        // Otherwise 1/(max_input-min_input) is not finite.
+        return None;
+    }
+
+    // Actually scale from [0,max] to [1,INTMAX], because it makes
+    // more sense in the case of load balancing.
+    let min_input = f64::min(min_input, 0.0);
+
+    let max_output = ((max_input - min_input) * O::max_value().to_f64().unwrap() + sum
+        - max_input * count as f64)
+        / (sum - min_input * count as f64);
+
+    let scale = (max_output - 1.0) / (max_input - min_input);
+    let offset = (max_input - max_output * min_input) / (max_input - min_input);
+
+    let scaled_inputs: Vec<O> = inputs
         .flat_map(move |v| {
-            v.into_iter()
-                .map(move |v| O::from(v.to_f64().unwrap() * zoom_factor).unwrap() + _1)
+            v.into_iter().map(move |v| {
+                let v = v.to_f64().unwrap();
+                O::from(f64::mul_add(v, scale, offset)).unwrap()
+            })
         })
-        .collect()
+        .collect();
+
+    let Some(first_input) = scaled_inputs.first() else {
+        return None;
+    };
+    if scaled_inputs.iter().all(|i| i == first_input) {
+        None
+    } else {
+        Some(scaled_inputs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zoom_in() {
+        let z = zoom_in::<_, i32, _>(vec![[1.0 - f64::EPSILON], [1.0], [1.0 + f64::EPSILON]]);
+        assert!(z.is_none());
+
+        let z: Vec<i32> = zoom_in(vec![[0.0], [1.0]]).unwrap();
+        assert_eq!(z, vec![1, i32::MAX - 1]);
+
+        let z: Vec<i32> = zoom_in(vec![[0.0], [1.0], [1.0]]).unwrap();
+        assert_eq!(z, vec![1, i32::MAX / 2, i32::MAX / 2]);
+
+        let z = zoom_in::<_, i32, _>(vec![[i32::MAX - 2], [i32::MAX - 1], [i32::MAX]]);
+        assert!(z.is_none());
+
+        let z: Vec<i32> = zoom_in(vec![[i32::MAX - 6], [i32::MAX - 3], [i32::MAX]]).unwrap();
+        assert_eq!(z, vec![i32::MAX / 3 - 1, i32::MAX / 3, i32::MAX / 3 + 1]);
+    }
 }


### PR DESCRIPTION
The idea is that we have weights
- in some [min; max] range,
- whose sum is S

and we want to scale them so
1. they fit into some integer type,
2. the output sum is below INTMAX
3. the output has no zeroes

basically we apply an affine function "y=scale*x+offset" where scale and offset depend on the max output value M:

         (M-1) * x + max - M*min
    y = -------------------------
               max - min

y=1 for x=min and y=M for x=max

M is set so that the sum of all "y" is INTMAX (N is the number of weights):

         (max - min) * INTMAX + sum(x) - max * N
    M = -----------------------------------------
                   sum(x) - min * N