### PR TITLE
tool: fixes and improvements related to cargo features

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -12,10 +12,17 @@ repository = "https://github.com/LIHPC-Computational-Geometry/coupe"
 
 
 [features]
-default = ["scotch", "metis"]
+default = []
 
-# Implicit features
-# - ittapi: enable integration with Intel performance tools
+# Integrate with Intel performance tools
+# See tools/README.md for details.
+intel-perf = ["dep:ittapi"]
+
+# Add METIS partitioning procedures as algorithms
+metis = ["dep:metis"]
+
+# Add SCOTCH partitioning procedures as algorithms
+scotch = ["dep:scotch"]
 
 
 [dependencies]

--- a/tools/README.md
+++ b/tools/README.md
@@ -60,15 +60,13 @@ cargo build -p mesh-io-ffi
 ### Integration with other partitioners
 
 The `mesh-part` and `part-bench` tools have optional support for [METIS] and
-[SCOTCH] that is enabled by default.  To disable these features, use the
-`--no-default-features` command-line flag.
+[SCOTCH] that is disabled by default.  To enable these features, use the
+`--features` command-line flag as shown below. Note that these features require
+a working clang install (version 5.0 or higher).
 
-```
-# Disable SCOTCH and METIS support
-cargo build --bins --no-default-features
-
-# Enable METIS support only
-cargo build --bins --no-default-features --features metis
+```sh
+# Enable SCOTCH and METIS algorithms
+cargo build --bins --features metis,scotch
 ```
 
 ### Integration with Intel performance tools
@@ -76,10 +74,10 @@ cargo build --bins --no-default-features --features metis
 The `mesh-part` and `part-bench` tools can better integrate with Intel VTune and
 Advisor through the use of *Instrumentation and Tracing Technology APIs*.
 
-To enable this integration, do so through the `ittapi` cargo feature:
+To enable this integration, do so through the `intel-perf` cargo feature:
 
-```
-cargo build --bins --feature ittapi
+```sh
+cargo build --bins --feature intel-perf
 ```
 
 When enabled, `mesh-part` and `part-bench` will wrap algorithm calls into

--- a/tools/src/bin/apply-part.rs
+++ b/tools/src/bin/apply-part.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use anyhow::Result;
 use mesh_io::ElementType;
-use std::env;
 use std::fs;
 use std::io;
 
@@ -9,25 +8,11 @@ const USAGE: &str = "Usage: apply-part [options] [out-mesh] >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("m", "mesh", "mesh file", "FILE");
     options.optopt("p", "partition", "partition file", "FILE");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("apply-part version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 1 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 1)?;
 
     let format = matches
         .opt_get("f")

--- a/tools/src/bin/apply-weight.rs
+++ b/tools/src/bin/apply-weight.rs
@@ -2,7 +2,6 @@ use anyhow::Context as _;
 use anyhow::Result;
 use mesh_io::ElementType;
 use mesh_io::Mesh;
-use std::env;
 use std::fs;
 use std::io;
 
@@ -26,25 +25,11 @@ fn apply(mesh: &mut Mesh, weights: impl Iterator<Item = isize>) {
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("m", "mesh", "mesh file", "FILE");
     options.optopt("w", "weights", "weight file", "FILE");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("apply-weight version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 1 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 1)?;
 
     let format = matches
         .opt_get("f")

--- a/tools/src/bin/mesh-dup.rs
+++ b/tools/src/bin/mesh-dup.rs
@@ -1,29 +1,14 @@
 use anyhow::Context as _;
 use anyhow::Result;
-use std::env;
 
 const USAGE: &str = "Usage: mesh-dup [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt("n", "times", "numbers of duplicates (default: 2)", "NUMBER");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("mesh-dup version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let format = matches
         .opt_get("f")

--- a/tools/src/bin/mesh-part.rs
+++ b/tools/src/bin/mesh-part.rs
@@ -9,7 +9,6 @@ use coupe::nalgebra::DimSub;
 use coupe::nalgebra::ToTypenum;
 use mesh_io::weight;
 use mesh_io::Mesh;
-use std::env;
 use std::fs;
 use std::io;
 use tracing_subscriber::filter::EnvFilter;
@@ -76,8 +75,6 @@ where
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optmulti(
         "a",
         "algorithm",
@@ -95,19 +92,7 @@ fn main() -> Result<()> {
     options.optflag("v", "verbose", "print diagnostic data");
     options.optopt("w", "weights", "weight file", "FILE");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("mesh-part version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 1 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 1)?;
 
     let registry = Registry::default().with(EnvFilter::from_env("LOG")).with(
         HierarchicalLayer::new(4)

--- a/tools/src/bin/mesh-points.rs
+++ b/tools/src/bin/mesh-points.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use mesh_io::ElementType;
 use mesh_io::Mesh;
-use std::env;
 use std::io;
 
 const USAGE: &str = "Usage: mesh-points [options] [in-mesh [out-plot]] <in.mesh >out.plot";
@@ -50,18 +49,9 @@ fn write_points<const D: usize>(mut w: impl io::Write, mesh: &Mesh, with_ids: bo
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
     options.optflag("", "with-ids", "add a column with the cell id");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        eprintln!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let mesh = coupe_tools::read_mesh(matches.free.get(0))?;
     let output = coupe_tools::writer(matches.free.get(1))?;

--- a/tools/src/bin/mesh-refine.rs
+++ b/tools/src/bin/mesh-refine.rs
@@ -1,13 +1,10 @@
 use anyhow::Context as _;
 use anyhow::Result;
-use std::env;
 
 const USAGE: &str = "Usage: mesh-refine [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
     options.optopt(
         "n",
@@ -16,19 +13,7 @@ fn main() -> Result<()> {
         "NUMBER",
     );
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("mesh-refine version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let format = matches
         .opt_get("f")

--- a/tools/src/bin/mesh-reorder.rs
+++ b/tools/src/bin/mesh-reorder.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use anyhow::Result;
 use mesh_io::Mesh;
-use std::env;
 
 const USAGE: &str = "Usage: mesh-reorder [options] [in-mesh [out-mesh]] <in.mesh >out.mesh";
 
@@ -62,23 +61,9 @@ where
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt("f", "format", "output format", "EXT");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("mesh-reorder version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let format = matches
         .opt_get("f")

--- a/tools/src/bin/mesh-svg.rs
+++ b/tools/src/bin/mesh-svg.rs
@@ -6,7 +6,6 @@ use mesh_io::Mesh;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
 use std::collections::HashSet;
-use std::env;
 use std::io;
 
 const USAGE: &str = "Usage: mesh-svg [options] [in-mesh [out-svg]] <in.mesh >out.svg";
@@ -318,27 +317,13 @@ where
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optflag(
         "o",
         "no-optimize",
         "do not merge elements of the same ref together",
     );
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("mesg-svg version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let mesh = coupe_tools::read_mesh(matches.free.get(0))?;
     let output = coupe_tools::writer(matches.free.get(1))?;

--- a/tools/src/bin/part-bench.rs
+++ b/tools/src/bin/part-bench.rs
@@ -10,7 +10,6 @@ use coupe::nalgebra::ToTypenum;
 use criterion::Criterion;
 use mesh_io::weight;
 use mesh_io::Mesh;
-use std::env;
 use std::fs;
 use std::io;
 use std::iter;
@@ -245,8 +244,6 @@ fn main() -> Result<()> {
     eprintln!("Warning: This is a debug build of part-bench, benchmarks will not reflect real-world performance.");
 
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optmulti(
         "a",
         "algorithm",
@@ -264,19 +261,7 @@ fn main() -> Result<()> {
     options.optopt("w", "weights", "weight file", "FILE");
     criterion_options(&mut options);
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("part-bench version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if !matches.free.is_empty() {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 0)?;
 
     let edge_weights = matches
         .opt_get("E")

--- a/tools/src/bin/part-info.rs
+++ b/tools/src/bin/part-info.rs
@@ -14,7 +14,6 @@ use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
 use std::collections::HashSet;
-use std::env;
 use std::fmt;
 use std::fs;
 use std::io;
@@ -194,8 +193,6 @@ where
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optopt(
         "E",
         "edge-weights",
@@ -207,19 +204,7 @@ fn main() -> Result<()> {
     options.optopt("p", "partition", "partition file", "FILE");
     options.optopt("w", "weights", "path to a weight file", "FILE");
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage("Usage: part-info [options]"));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("part-info version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if !matches.free.is_empty() {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 0)?;
 
     let edge_weights = matches
         .opt_get("E")

--- a/tools/src/bin/weight-gen.rs
+++ b/tools/src/bin/weight-gen.rs
@@ -5,7 +5,6 @@ use mesh_io::Mesh;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
 use std::cmp;
-use std::env;
 
 const USAGE: &str = "Usage: weight-gen [options] [in-mesh [out-weights]] <in.mesh >out.weights";
 
@@ -188,8 +187,6 @@ fn weight_gen<const D: usize>(
 
 fn main() -> Result<()> {
     let mut options = getopts::Options::new();
-    options.optflag("h", "help", "print this help menu");
-    options.optflag("", "version", "print version information");
     options.optmulti(
         "d",
         "distribution",
@@ -202,19 +199,7 @@ fn main() -> Result<()> {
         "generate integers instead of floating-point numbers",
     );
 
-    let matches = options.parse(env::args().skip(1))?;
-
-    if matches.opt_present("h") {
-        println!("{}", options.usage(USAGE));
-        return Ok(());
-    }
-    if matches.opt_present("version") {
-        println!("weight-gen version {}", env!("COUPE_VERSION"));
-        return Ok(());
-    }
-    if matches.free.len() > 2 {
-        anyhow::bail!("too many arguments\n\n{}", options.usage(USAGE));
-    }
+    let matches = coupe_tools::parse_args(options, USAGE, 2)?;
 
     let distributions = matches.opt_strs("d");
     if distributions.is_empty() {

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -9,9 +9,6 @@ use coupe::nalgebra::DefaultAllocator;
 use coupe::nalgebra::DimDiff;
 use coupe::nalgebra::DimSub;
 use coupe::nalgebra::ToTypenum;
-use coupe::num_traits::PrimInt;
-use coupe::num_traits::ToPrimitive;
-use coupe::num_traits::Zero;
 use coupe::sprs::CsMat;
 use coupe::sprs::CsMatView;
 use coupe::sprs::CSR;
@@ -29,14 +26,14 @@ use rayon::slice::ParallelSlice as _;
 use std::any;
 use std::fs::File;
 use std::io;
-use std::iter::Sum;
 use std::mem;
-use std::ops::AddAssign;
 
 #[cfg(feature = "metis")]
 mod metis;
 #[cfg(feature = "scotch")]
 mod scotch;
+#[cfg(any(feature = "metis", feature = "scotch"))]
+mod zoom_in;
 
 #[cfg_attr(not(feature = "ittapi"), path = "ittapi_stub.rs")]
 pub mod ittapi;
@@ -812,42 +809,4 @@ pub fn write_mesh(
         MeshFormat::VtkBinary => mesh.serialize_vtk_binary(w)?,
     }
     Ok(())
-}
-
-#[cfg(any(feature = "metis", feature = "scotch"))]
-fn zoom_in<I, O, W>(inputs: I) -> Vec<O>
-where
-    I: IntoIterator,
-    I::IntoIter: Clone + ExactSizeIterator,
-    I::Item: IntoIterator<Item = W>,
-    W: Sum + AddAssign + Clone + Zero + PartialOrd + ToPrimitive,
-    O: PrimInt,
-{
-    let inputs = inputs.into_iter();
-    let criterion_count = match inputs.clone().next() {
-        Some(v) => v.into_iter().count(),
-        None => return Vec::new(),
-    };
-    let sum = inputs
-        .clone()
-        .fold(vec![W::zero(); criterion_count], |mut acc, w| {
-            for (acc, w) in acc.iter_mut().zip(w) {
-                *acc += w;
-            }
-            acc
-        })
-        .into_iter()
-        .max_by(|a, b| W::partial_cmp(a, b).unwrap())
-        .unwrap();
-    let zoom_factor = (O::max_value() - O::from(inputs.len()).unwrap())
-        .to_f64()
-        .unwrap()
-        / sum.to_f64().unwrap();
-    let _1 = O::one();
-    inputs
-        .flat_map(move |v| {
-            v.into_iter()
-                .map(move |v| O::from(v.to_f64().unwrap() * zoom_factor).unwrap() + _1)
-        })
-        .collect()
 }

--- a/tools/src/metis.rs
+++ b/tools/src/metis.rs
@@ -1,6 +1,7 @@
 use super::Problem;
 use super::Runner;
 use super::ToRunner;
+use crate::zoom_in::zoom_in;
 use anyhow::Context;
 use mesh_io::weight;
 use metis::Idx;
@@ -15,12 +16,12 @@ impl<const D: usize> ToRunner<D> for Recursive {
         let (ncon, mut weights) = match &problem.weights {
             weight::Array::Integers(is) => {
                 let ncon = is.first().map_or(1, Vec::len) as Idx;
-                let weights = crate::zoom_in(is.iter().map(|v| v.iter().cloned()));
+                let weights = zoom_in(is.iter().map(|v| v.iter().cloned()));
                 (ncon, weights)
             }
             weight::Array::Floats(fs) => {
                 let ncon = fs.first().map_or(1, Vec::len) as Idx;
-                let weights = crate::zoom_in(fs.iter().map(|v| v.iter().cloned()));
+                let weights = zoom_in(fs.iter().map(|v| v.iter().cloned()));
                 (ncon, weights)
             }
         };
@@ -28,7 +29,7 @@ impl<const D: usize> ToRunner<D> for Recursive {
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
+        let mut adjwgt: Vec<_> = zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let tolerance = self.tolerance.map(|f| (f * 1000.0) as Idx);
 
@@ -61,12 +62,12 @@ impl<const D: usize> ToRunner<D> for KWay {
         let (ncon, mut weights) = match &problem.weights {
             weight::Array::Integers(is) => {
                 let ncon = is.first().map_or(1, Vec::len) as Idx;
-                let weights = crate::zoom_in(is.iter().map(|v| v.iter().cloned()));
+                let weights = zoom_in(is.iter().map(|v| v.iter().cloned()));
                 (ncon, weights)
             }
             weight::Array::Floats(fs) => {
                 let ncon = fs.first().map_or(1, Vec::len) as Idx;
-                let weights = crate::zoom_in(fs.iter().map(|v| v.iter().cloned()));
+                let weights = zoom_in(fs.iter().map(|v| v.iter().cloned()));
                 (ncon, weights)
             }
         };
@@ -74,7 +75,7 @@ impl<const D: usize> ToRunner<D> for KWay {
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let mut xadj: Vec<_> = xadj.iter().map(|i| *i as Idx).collect();
         let mut adjncy: Vec<_> = adjncy.iter().map(|i| *i as Idx).collect();
-        let mut adjwgt: Vec<_> = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
+        let mut adjwgt: Vec<_> = zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let tolerance = self.tolerance.map(|f| (f * 1000.0) as Idx);
 

--- a/tools/src/scotch.rs
+++ b/tools/src/scotch.rs
@@ -1,6 +1,7 @@
 use super::runner_error;
 use super::Problem;
 use super::ToRunner;
+use crate::zoom_in::zoom_in;
 use anyhow::Context as _;
 use mesh_io::weight;
 use scotch::graph::Data;
@@ -18,20 +19,20 @@ impl<const D: usize> ToRunner<D> for Standard {
                 if is.first().map_or(1, Vec::len) != 1 {
                     return runner_error("SCOTCH cannot do multi-criteria partitioning");
                 }
-                crate::zoom_in(is.iter().map(|v| Some(v[0])))
+                zoom_in(is.iter().map(|v| Some(v[0])))
             }
             weight::Array::Floats(fs) => {
                 if fs.first().map_or(1, Vec::len) != 1 {
                     return runner_error("SCOTCH cannot do multi-criteria partitioning");
                 }
-                crate::zoom_in(fs.iter().map(|v| Some(v[0])))
+                zoom_in(fs.iter().map(|v| Some(v[0])))
             }
         };
 
         let (xadj, adjncy, adjwgt) = problem.adjacency().into_raw_storage();
         let xadj: Vec<_> = xadj.iter().map(|i| *i as Num).collect();
         let adjncy: Vec<_> = adjncy.iter().map(|i| *i as Num).collect();
-        let adjwgt = crate::zoom_in(adjwgt.iter().map(|v| Some(*v)));
+        let adjwgt = zoom_in(adjwgt.iter().map(|v| Some(*v)));
 
         let mut strat = scotch::Strategy::new();
         let arch = scotch::Architecture::complete(self.part_count as Num);

--- a/tools/src/zoom_in.rs
+++ b/tools/src/zoom_in.rs
@@ -1,0 +1,42 @@
+use coupe::num_traits::PrimInt;
+use coupe::num_traits::ToPrimitive;
+use coupe::num_traits::Zero;
+use std::iter::Sum;
+use std::ops::AddAssign;
+
+pub fn zoom_in<I, O, W>(inputs: I) -> Vec<O>
+where
+    I: IntoIterator,
+    I::IntoIter: Clone + ExactSizeIterator,
+    I::Item: IntoIterator<Item = W>,
+    W: Sum + AddAssign + Clone + Zero + PartialOrd + ToPrimitive,
+    O: PrimInt,
+{
+    let inputs = inputs.into_iter();
+    let criterion_count = match inputs.clone().next() {
+        Some(v) => v.into_iter().count(),
+        None => return Vec::new(),
+    };
+    let sum = inputs
+        .clone()
+        .fold(vec![W::zero(); criterion_count], |mut acc, w| {
+            for (acc, w) in acc.iter_mut().zip(w) {
+                *acc += w;
+            }
+            acc
+        })
+        .into_iter()
+        .max_by(|a, b| W::partial_cmp(a, b).unwrap())
+        .unwrap();
+    let zoom_factor = (O::max_value() - O::from(inputs.len()).unwrap())
+        .to_f64()
+        .unwrap()
+        / sum.to_f64().unwrap();
+    let _1 = O::one();
+    inputs
+        .flat_map(move |v| {
+            v.into_iter()
+                .map(move |v| O::from(v.to_f64().unwrap() * zoom_factor).unwrap() + _1)
+        })
+        .collect()
+}


### PR DESCRIPTION
some quality of life improvements

- show enable cargo features on `bin --version` (useful to known when intel profiling support is enabled)
- disable scotch and metis by default (since they require clang)
- fix some dead code warnings when scotch and metis are disabled