### PR TITLE
fix: check `--all-features` option in CI and fix identified issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         run: sudo apt-get -y install libclang-dev libmetis-dev libscotch-dev
       - name: Run tests (default features)
         run: cargo test --all
-      - name: Run tests (all features)
-        run: cargo test --all
 
   fmt:
     name: Format
@@ -83,4 +81,4 @@ jobs:
       - name: Build crates (default features)
         run: cargo build --all-targets
       - name: Build crates (all features)
-        run: cargo build --all-targets
+        run: cargo build --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: sudo apt-get -y install libclang-dev libmetis-dev libscotch-dev
-      - name: Run tests
+      - name: Run tests (default features)
+        run: cargo test --all
+      - name: Run tests (all features)
         run: cargo test --all
 
   fmt:
@@ -78,5 +80,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: sudo apt-get -y install libclang-dev libmetis-dev libscotch-dev
-      - name: Build crates
+      - name: Build crates (default features)
+        run: cargo build --all-targets
+      - name: Build crates (all features)
         run: cargo build --all-targets

--- a/coupe/Cargo.toml
+++ b/coupe/Cargo.toml
@@ -16,7 +16,7 @@ geometric and topologic algorithms.
 name = "coupe"
 
 [features]
-default = ["sprs"]
+default = ["sprs", "avx512"]
 
 # Enable the nightly `stdsimd` feature and AVX512-accelerated algorithms.
 # Requires rust nightly.

--- a/coupe/Cargo.toml
+++ b/coupe/Cargo.toml
@@ -16,7 +16,7 @@ geometric and topologic algorithms.
 name = "coupe"
 
 [features]
-default = ["sprs", "avx512"]
+default = ["sprs"]
 
 # Enable the nightly `stdsimd` feature and AVX512-accelerated algorithms.
 # Requires rust nightly.

--- a/coupe/src/algorithms/recursive_bisection.rs
+++ b/coupe/src/algorithms/recursive_bisection.rs
@@ -251,18 +251,18 @@ fn reorder_split_avx512<const D: usize, W>(
 
             for coord in 0..D {
                 _mm256_mask_compressstoreu_ps(
-                    items.points[coord].as_mut_ptr().add(lw) as *mut u8,
+                    items.points[coord].as_mut_ptr().add(lw),
                     mask,
                     val[coord],
                 );
             }
             _mm512_mask_compressstoreu_epi64(
-                items.weights.as_mut_ptr().add(lw) as *mut u8,
+                items.weights.as_mut_ptr().add(lw) as *mut i64, // TODO: test
                 mask,
                 val_weights,
             );
             _mm512_mask_compressstoreu_epi64(
-                items.parts.as_mut_ptr().add(lw) as *mut u8,
+                items.parts.as_mut_ptr().add(lw) as *mut i64, // TODO: test
                 mask,
                 val_parts,
             );
@@ -271,18 +271,18 @@ fn reorder_split_avx512<const D: usize, W>(
             rw -= nb_high;
             for coord in 0..D {
                 _mm256_mask_compressstoreu_ps(
-                    items.points[coord].as_mut_ptr().add(rw) as *mut u8,
+                    items.points[coord].as_mut_ptr().add(rw),
                     !mask,
                     val[coord],
                 );
             }
             _mm512_mask_compressstoreu_epi64(
-                items.weights.as_mut_ptr().add(rw) as *mut u8,
+                items.weights.as_mut_ptr().add(rw) as *mut i64, // TODO: test
                 !mask,
                 val_weights,
             );
             _mm512_mask_compressstoreu_epi64(
-                items.parts.as_mut_ptr().add(rw) as *mut u8,
+                items.parts.as_mut_ptr().add(rw) as *mut i64, // TODO: test
                 !mask,
                 val_parts,
             );
@@ -300,18 +300,18 @@ fn reorder_split_avx512<const D: usize, W>(
         let nb_high = mask_high.count_ones() as usize;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(lw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(lw),
                 mask_low,
                 val[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(lw) as *mut u8,
+            items.weights.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask_low,
             val_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(lw) as *mut u8,
+            items.parts.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask_low,
             val_parts,
         );
@@ -319,18 +319,18 @@ fn reorder_split_avx512<const D: usize, W>(
         rw -= nb_high;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(rw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(rw),
                 mask_high,
                 val[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(rw) as *mut u8,
+            items.weights.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             mask_high,
             val_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(rw) as *mut u8,
+            items.parts.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             mask_high,
             val_parts,
         );
@@ -340,18 +340,18 @@ fn reorder_split_avx512<const D: usize, W>(
         let nb_high = AVX2_REGISTER_BYTES - nb_low;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(lw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(lw),
                 mask,
                 lv[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(lw) as *mut u8,
+            items.weights.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask,
             lv_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(lw) as *mut u8,
+            items.parts.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask,
             lv_parts,
         );
@@ -359,18 +359,18 @@ fn reorder_split_avx512<const D: usize, W>(
         rw -= nb_high;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(rw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(rw),
                 !mask,
                 lv[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(rw) as *mut u8,
+            items.weights.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             !mask,
             lv_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(rw) as *mut u8,
+            items.parts.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             !mask,
             lv_parts,
         );
@@ -380,18 +380,18 @@ fn reorder_split_avx512<const D: usize, W>(
         let nb_high = AVX2_REGISTER_BYTES - nb_low;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(lw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(lw),
                 mask,
                 rv[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(lw) as *mut u8,
+            items.weights.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask,
             rv_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(lw) as *mut u8,
+            items.parts.as_mut_ptr().add(lw) as *mut i64, // TODO: test
             mask,
             rv_parts,
         );
@@ -399,18 +399,18 @@ fn reorder_split_avx512<const D: usize, W>(
         rw -= nb_high;
         for coord in 0..D {
             _mm256_mask_compressstoreu_ps(
-                items.points[coord].as_mut_ptr().add(rw) as *mut u8,
+                items.points[coord].as_mut_ptr().add(rw),
                 !mask,
                 rv[coord],
             );
         }
         _mm512_mask_compressstoreu_epi64(
-            items.weights.as_mut_ptr().add(rw) as *mut u8,
+            items.weights.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             !mask,
             rv_weights,
         );
         _mm512_mask_compressstoreu_epi64(
-            items.parts.as_mut_ptr().add(rw) as *mut u8,
+            items.parts.as_mut_ptr().add(rw) as *mut i64, // TODO: test
             !mask,
             rv_parts,
         );

--- a/coupe/src/lib.rs
+++ b/coupe/src/lib.rs
@@ -29,7 +29,6 @@
 //! - [Fiduccia-Mattheyses][FiducciaMattheyses]
 //! - [Kernighan-Lin][KernighanLin]
 
-#![cfg_attr(feature = "avx512", feature(stdsimd))]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/tools/lib/metis.rs
+++ b/tools/lib/metis.rs
@@ -35,7 +35,7 @@ impl<const D: usize> ToRunner<D> for Recursive {
 
         let mut metis_partition = vec![0; problem.adjacency().rows()];
         Box::new(move |partition| {
-            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy);
+            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy)?;
             if let Some(weights) = &mut weights {
                 graph = graph.set_vwgt(weights);
             }
@@ -85,7 +85,7 @@ impl<const D: usize> ToRunner<D> for KWay {
 
         let mut metis_partition = vec![0; problem.adjacency().rows()];
         Box::new(move |partition| {
-            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy);
+            let mut graph = metis::Graph::new(ncon, self.part_count, &mut xadj, &mut adjncy)?;
             if let Some(weights) = &mut weights {
                 graph = graph.set_vwgt(weights);
             }


### PR DESCRIPTION
The build CI was not checking builds with all features enabled, so it was missing some errors in builds using `avx512` or `metis`. I added another step to the workflow with the `--all-features` option to catch those.

I also fixed the issues.